### PR TITLE
Avoid redefinitions of JIT'ed functions in repeated calls

### DIFF
--- a/src/adaptive_SNN/solver/solver.py
+++ b/src/adaptive_SNN/solver/solver.py
@@ -103,12 +103,7 @@ def simulate_noisy_SNN(
 @eqx.filter_jit
 def save_state(args, save_fn, carry, t):
     """Helper to save the state at the specified index."""
-    print("Compiling save_state")
-    (
-        y,
-        ys,
-        save_index,
-    ) = carry
+    y, ys, save_index = carry
     ys = jax.tree_util.tree_map(
         lambda arr, v: arr.at[save_index].set(v), ys, save_fn(t, y, args)
     )
@@ -118,8 +113,6 @@ def save_state(args, save_fn, carry, t):
 @eqx.filter_jit
 def step(times, solver, terms, args, save_mask, model, save_fn, i, carry):
     """Inner loop of the simulation. Takes one step and saves if needed."""
-
-    print("Compiling step")
     y, ys, save_index = carry
 
     # Take a step


### PR DESCRIPTION
JIT'ing run_simulation is not really necessary, as we generally only simulate a network once. If the network/args change, this  function would be recompiled anyway. Thus, its easier to save the time and effor to JIT this function. This might in the future if more of the network information would be stored in the state variable instead of as class attributes, avoiding the need to recompile when the network changes.

Furthermore, the inner functions were being redefined every time run_simulation was called. Moving them outside avoids this redefinition overhead, and allows them to be reused across multiple calls to run_simulation.