### PR TITLE
Allow none noise

### DIFF
--- a/src/adaptive_SNN/models/environments/__init__.py
+++ b/src/adaptive_SNN/models/environments/__init__.py
@@ -1,4 +1,7 @@
-from adaptive_SNN.models.environments.double_integrator import DoubleIntegrator
+from adaptive_SNN.models.environments.double_integrator import (
+    DoubleIntegrator,
+    DoubleIntegratorKickControl,
+)
 from adaptive_SNN.models.environments.input_tracking import InputTrackingEnvironment
 from adaptive_SNN.models.environments.spike_rate import SpikeRateEnvironment
 
@@ -6,4 +9,5 @@ __all__ = [
     "InputTrackingEnvironment",
     "SpikeRateEnvironment",
     "DoubleIntegrator",
+    "DoubleIntegratorKickControl",
 ]

--- a/src/adaptive_SNN/models/environments/double_integrator.py
+++ b/src/adaptive_SNN/models/environments/double_integrator.py
@@ -3,6 +3,7 @@ import jax
 import jax.numpy as jnp
 
 from adaptive_SNN.models.base import EnvironmentABC
+from adaptive_SNN.utils.operators import DefaultIfNone, ElementWiseMul
 
 default_float = jnp.float64 if jax.config.jax_enable_x64 else jnp.float32
 
@@ -22,7 +23,7 @@ class DoubleIntegrator(EnvironmentABC):
 
     @property
     def noise_shape(self):
-        return jax.ShapeDtypeStruct(shape=(self.dim,), dtype=default_float)
+        return None
 
     def drift(self, t, x, args):
         if args is None or "get_env_input" not in args:
@@ -30,14 +31,17 @@ class DoubleIntegrator(EnvironmentABC):
                 "DoubleIntegrator requires 'get_env_input' in args for drift computation."
             )
 
+        acceleration = self.rate * args["get_env_input"](t, x, args)
+
         dxdt = jnp.array(
-            [x.at[1].get(), 0.0]
-        )  # dx/dt = velocity, dv/dt = 0 (no acceleration)
+            [x.at[1].get(), acceleration]
+        )  # dx/dt = velocity, dv/dt = input
         return dxdt
 
     def diffusion(self, t, x, args):
-        # TODO: implement noise
-        return jnp.zeros((self.dim, self.dim))
+        return DefaultIfNone(
+            default=jnp.zeros_like(x), else_do=ElementWiseMul(jnp.zeros_like(x))
+        )
 
     def terms(self, key):
         process_noise = dfx.UnsafeBrownianPath(
@@ -48,5 +52,50 @@ class DoubleIntegrator(EnvironmentABC):
         )
 
     def update(self, t, x, args):
-        acceleration = self.rate * args["get_env_input"](t, x, args)
-        return x.at[1].add(acceleration)  # Update velocity with acceleration
+        return x
+
+
+class DoubleIntegratorKickControl(EnvironmentABC):
+    """Double integrator environment controlled using discrete kicks."""
+
+    dim: int = 2  # State is 2-dimensional: [position, velocity]
+    rate: float = 1.0  # Rate at which the environment responds to input
+
+    def __init__(self, rate: float = 1.0):
+        self.rate = rate
+
+    @property
+    def initial(self):
+        return jnp.zeros((self.dim,))
+
+    @property
+    def noise_shape(self):
+        return None
+
+    def drift(self, t, x, args):
+        # Position is updated as usual, velocity is not changed here, but in update
+        dxdt = jnp.array([x.at[1].get(), 0.0])
+        return dxdt
+
+    def diffusion(self, t, x, args):
+        return DefaultIfNone(
+            default=jnp.zeros_like(x), else_do=ElementWiseMul(jnp.zeros_like(x))
+        )
+
+    def terms(self, key):
+        process_noise = dfx.UnsafeBrownianPath(
+            shape=self.noise_shape, key=key, levy_area=dfx.SpaceTimeLevyArea
+        )
+        return dfx.MultiTerm(
+            dfx.ODETerm(self.drift), dfx.ControlTerm(self.diffusion, process_noise)
+        )
+
+    def update(self, t, x, args):
+        """Discrete update to apply velocity kick based on input."""
+        if args is None or "get_env_input" not in args:
+            raise ValueError(
+                "DoubleIntegratorKickControl requires 'get_env_input' in args for update."
+            )
+        acceleration_kick = self.rate * args["get_env_input"](t, x, args)
+        x = x.at[1].set(x.at[1].get() + acceleration_kick)  # Update velocity with kick
+        return x

--- a/src/adaptive_SNN/models/environments/input_tracking.py
+++ b/src/adaptive_SNN/models/environments/input_tracking.py
@@ -3,6 +3,7 @@ import jax
 import jax.numpy as jnp
 
 from adaptive_SNN.models.base import EnvironmentABC
+from adaptive_SNN.utils.operators import DefaultIfNone, ElementWiseMul
 
 default_float = jnp.float64 if jax.config.jax_enable_x64 else jnp.float32
 
@@ -23,7 +24,7 @@ class InputTrackingEnvironment(EnvironmentABC):
 
     @property
     def noise_shape(self):
-        return jax.ShapeDtypeStruct(shape=(self.dim,), dtype=default_float)
+        return None
 
     def drift(self, t, x, args):
         if args is None or "get_env_input" not in args:
@@ -35,7 +36,9 @@ class InputTrackingEnvironment(EnvironmentABC):
         )  # Simple dynamics towards input
 
     def diffusion(self, t, x, args):
-        return jnp.zeros((self.dim, self.dim))
+        return DefaultIfNone(
+            default=jnp.zeros_like(x), else_do=ElementWiseMul(jnp.zeros_like(x))
+        )
 
     def terms(self, key):
         process_noise = dfx.UnsafeBrownianPath(

--- a/src/adaptive_SNN/models/environments/spike_rate.py
+++ b/src/adaptive_SNN/models/environments/spike_rate.py
@@ -3,7 +3,7 @@ import jax
 import jax.numpy as jnp
 
 from adaptive_SNN.models.base import EnvironmentABC
-from adaptive_SNN.utils import ElementWiseMul
+from adaptive_SNN.utils.operators import DefaultIfNone, ElementWiseMul
 
 default_float = jnp.float64 if jax.config.jax_enable_x64 else jnp.float32
 
@@ -29,13 +29,15 @@ class SpikeRateEnvironment(EnvironmentABC):
 
     @property
     def noise_shape(self):
-        return jax.ShapeDtypeStruct(shape=(self.dim,), dtype=default_float)
+        return None
 
     def drift(self, t, x, args):
         return -x  # Exponential decay of spike rate
 
     def diffusion(self, t, x, args):
-        return ElementWiseMul(jnp.zeros_like(x))
+        return DefaultIfNone(
+            default=jnp.zeros_like(x), else_do=ElementWiseMul(jnp.zeros_like(x))
+        )
 
     def terms(self, key):
         process_noise = dfx.UnsafeBrownianPath(

--- a/src/adaptive_SNN/models/reward.py
+++ b/src/adaptive_SNN/models/reward.py
@@ -3,6 +3,8 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 
+from adaptive_SNN.utils.operators import DefaultIfNone, ElementWiseMul
+
 default_float = jnp.float64 if jax.config.jax_enable_x64 else jnp.float32
 
 
@@ -16,10 +18,12 @@ class RewardModel(eqx.Module):
 
     @property
     def noise_shape(self):
-        return jax.ShapeDtypeStruct(shape=(self.dim,), dtype=default_float)
+        return None
 
     def diffusion(self, t, x, args):
-        return jnp.zeros((self.dim, self.dim))  # Zero diffusion for reward
+        return DefaultIfNone(
+            default=jnp.zeros_like(x), else_do=ElementWiseMul(jnp.zeros_like(x))
+        )
 
     def drift(self, t, x, args):
         if args is None or "reward" not in args:


### PR DESCRIPTION
(Partly) addresses #15. This PR prevents having to generate Brownian noise even for noiseless processes. Instead, a shape of None can be indicated in the noise_shape, which will lead to no noise being generated for that part of the state pytree. However, since the SDE solver expects a stochastic term to add to the regular term, the output of computing the diffusion does need to have the correct shape (i.e. the same as the state). To achieve this, the diffusion now uses the DefaultIfNone operator, which returns a default value when the input to the operator is None. 

Combining these, we can generate None's instead of noise, and when this None noise is multiplied by the diffusion, this outputs our pre-defined defaults (in this case, matrices of 0s with the correct shape). This way, we can produce a pytree of 0s in the same shape as the state, just as prior to this PR, but now with much less overhead.

However, we are still required to model everything as SDEs with a defined noise shape and diffusion term, even if the process is deterministic. This is necessary since everything is modeled as coupled systems, which either needs to be entirely stochastic (the stochastic term needs to have the same shape as the drift term, hence requiring all sub-systems to do so as well), or entirely deterministic (we always want some noise, so this is not relevant).

The overhead of modeling everything as an SDE is quite small though, thanks to this PR (e.g. the LIF is >50% faster than before).