### PR TITLE
Use NaN instead of -inf for non-existing weights

### DIFF
--- a/scripts/old/simulate_noisy_neuron.py
+++ b/scripts/old/simulate_noisy_neuron.py
@@ -55,7 +55,7 @@ def main():
 
         for E_weight in E_weights:
             for I_weight in I_weights:
-                initial_weight_matrix = jnp.array([[-jnp.inf, E_weight, I_weight]])
+                initial_weight_matrix = jnp.array([[jnp.nan, E_weight, I_weight]])
                 input_types = jnp.array([1, 0])  # 1 for excitatory, 0 for inhibitory
                 # Set up models
                 neuron_model = LIFNetwork(
@@ -239,7 +239,7 @@ def main():
             continue
 
         lower, upper = target
-        mask = jnp.isfinite(matrix) & (matrix >= lower) & (matrix <= upper)
+        mask = ~jnp.isnan(matrix) & (matrix >= lower) & (matrix <= upper)
         target_masks.append(mask)
 
     valid_target_masks = [mask for mask in target_masks if mask is not None]

--- a/scripts/plots/balanced_input_tuning.py
+++ b/scripts/plots/balanced_input_tuning.py
@@ -55,7 +55,7 @@ def main():
 
         for E_weight in E_weights:
             for I_weight in I_weights:
-                initial_weight_matrix = jnp.array([[-jnp.inf, E_weight, I_weight]])
+                initial_weight_matrix = jnp.array([[jnp.nan, E_weight, I_weight]])
                 input_types = jnp.array([1, 0])  # 1 for excitatory, 0 for inhibitory
                 # Set up models
                 neuron_model = LIFNetwork(
@@ -239,7 +239,7 @@ def main():
             continue
 
         lower, upper = target
-        mask = jnp.isfinite(matrix) & (matrix >= lower) & (matrix <= upper)
+        mask = ~jnp.isnan(matrix) & (matrix >= lower) & (matrix <= upper)
         target_masks.append(mask)
 
     valid_target_masks = [mask for mask in target_masks if mask is not None]

--- a/scripts/plots/plot_biofeedback_experiment.py
+++ b/scripts/plots/plot_biofeedback_experiment.py
@@ -69,14 +69,8 @@ def main():
 
             # Plot mean synaptic weight ot the target neuron and the entire network
             mean_w = method_group["W_mean"].values[0]
-            target_w = jnp.nanmean(
-                jnp.where(
-                    jnp.isfinite(method_group["W_target"].values[0]),
-                    method_group["W_target"].values[0],
-                    jnp.nan,
-                ),
-                axis=1,
-            )
+            target_w = jnp.nanmean(method_group["W_target"].values[0], axis=1)
+
             axs[1].plot(
                 ts[1:],
                 target_w[1:],

--- a/scripts/snellius/biofeedback_experiment/run.py
+++ b/scripts/snellius/biofeedback_experiment/run.py
@@ -70,13 +70,7 @@ def main():
             x.agent_state.noisy_network.network_state.S[0].astype(jnp.bool),
             x.agent_state.RPE.RPE.astype(jnp.float32),
             x.agent_state.noisy_network.network_state.W[0].astype(jnp.float32),
-            jnp.nanmean(
-                jnp.where(
-                    jnp.isfinite(x.agent_state.noisy_network.network_state.W),
-                    x.agent_state.noisy_network.network_state.W,
-                    jnp.nan,
-                )
-            ),
+            jnp.nanmean(x.agent_state.noisy_network.network_state.W),
             x.environment_state.astype(jnp.float32),
         )
 

--- a/src/adaptive_SNN/models/networks/base.py
+++ b/src/adaptive_SNN/models/networks/base.py
@@ -54,7 +54,7 @@ class LIFState(eqx.Module):
     Attributes:
         V: Membrane potentials (N_neurons,)
         S: Spike vector (N_neurons + N_inputs,)
-        W: Synaptic weight matrix (N_neurons, N_neurons + N_inputs). -inf indicates no connection
+        W: Synaptic weight matrix (N_neurons, N_neurons + N_inputs). NaN indicates no connection
         G: Synaptic conductances (N_neurons, N_neurons + N_inputs)
         auxiliary_info: AuxiliaryInfo object containing additional state variables
     """
@@ -314,7 +314,7 @@ class AbstractLIFNetwork(NeuronModelABC):
 
         # Compute total excitatory synaptic conductance per neuron
         W, G = state.W, state.G
-        weighted_conductances = jnp.where(jnp.isfinite(W), W, 0.0) * G
+        weighted_conductances = jnp.where(~jnp.isnan(W), W, 0.0) * G
         total_E_conductance_per_neuron = jnp.sum(
             weighted_conductances * self.excitatory_mask[None, :], axis=1
         )
@@ -458,7 +458,7 @@ class AbstractLIFNetwork(NeuronModelABC):
 
         # Compute E/I currents from recurrent connections
         weighted_conductances = (
-            jnp.where(W == -jnp.inf, 0.0, W) * G
+            jnp.where(jnp.isnan(W), 0.0, W) * G
         )  # For non-existing connections, set weighted conductance to 0
         total_I_conductances = jnp.sum(
             weighted_conductances * jnp.invert(self.excitatory_mask[None, :]), axis=1
@@ -498,7 +498,7 @@ class AbstractLIFNetwork(NeuronModelABC):
         return eqx.tree_at(
             lambda s: s.W,
             state,
-            jnp.where(jnp.isfinite(state.W), jnp.clip(state.W, min=0.0), state.W),
+            jnp.where(~jnp.isnan(state.W), jnp.clip(state.W, min=0.0), state.W),
         )
 
     def get_delayed_spikes(self, state: LIFState) -> Array:
@@ -589,7 +589,7 @@ class AbstractLIFNetwork(NeuronModelABC):
         )
 
         G_new = jnp.where(
-            W == -jnp.inf, 0.0, G_new
+            jnp.isnan(W), 0.0, G_new
         )  # Only update conductances for existing connections, else set to 0
 
         time_since_last_spike = jnp.where(
@@ -625,12 +625,12 @@ class AbstractLIFNetwork(NeuronModelABC):
         Returns NaN if a neuron has no non-zero excitatory or inhibitory connections.
         """
         weights = jnp.where(
-            state.W == -jnp.inf, 0.0, state.W
+            jnp.isnan(state.W), 0.0, state.W
         )  # Treat non-existing connections as weight 0 for balance computation
 
         # Create masks for existing connections
-        existing_E = jnp.isfinite(state.W) & self.excitatory_mask[None, :]
-        existing_I = jnp.isfinite(state.W) & ~self.excitatory_mask[None, :]
+        existing_E = ~jnp.isnan(state.W) & self.excitatory_mask[None, :]
+        existing_I = ~jnp.isnan(state.W) & ~self.excitatory_mask[None, :]
 
         N_E_connections = jnp.sum(existing_E, axis=1)
         N_I_connections = jnp.sum(existing_I, axis=1)
@@ -690,7 +690,7 @@ class AbstractLIFNetwork(NeuronModelABC):
         desired_balance = args["get_desired_balance"](t, state, args)
         total_I_weights = jnp.sum(
             jnp.where(
-                state.W == -jnp.inf,
+                jnp.isnan(state.W),
                 0.0,
                 state.W * jnp.invert(self.excitatory_mask[None, :]),
             ),
@@ -707,7 +707,7 @@ class AbstractLIFNetwork(NeuronModelABC):
                 )  # If desired balance is 0, we do not want to change the weights
                 & (total_I_weights == 0.0)[:, None]
                 & jnp.invert(self.excitatory_mask[None, :])
-                & jnp.isfinite(state.W),
+                & ~jnp.isnan(state.W),
                 1.0,
                 state.W,
             ),
@@ -730,7 +730,7 @@ class AbstractLIFNetwork(NeuronModelABC):
     def initialize_weights(self, key: jr.PRNGKey):
         """Initialize synaptic weight matrix with random sparse connections.
 
-        No self-connections are allowed. Non-existing connections have weight -inf.
+        No self-connections are allowed. Non-existing connections have weight NaN.
         """
         key, subkey, subkey2 = jr.split(key, 3)
 
@@ -755,11 +755,11 @@ class AbstractLIFNetwork(NeuronModelABC):
                 min=0.5,
                 max=1.5,
             ),
-            -jnp.inf,
+            jnp.nan,
         )
 
         # Remove self-connections
-        rec_weights = jnp.fill_diagonal(rec_weights, -jnp.inf, inplace=False)
+        rec_weights = jnp.fill_diagonal(rec_weights, jnp.nan, inplace=False)
 
         key, subkey = jr.split(key)
         N_input_connections = (
@@ -781,7 +781,7 @@ class AbstractLIFNetwork(NeuronModelABC):
         input_weights = jnp.where(
             input_mask,
             self.initial_input_weight,
-            -jnp.inf,
+            jnp.nan,
         )
 
         weights = jnp.concatenate([rec_weights, input_weights], axis=1)

--- a/src/adaptive_SNN/models/networks/default_LIF.py
+++ b/src/adaptive_SNN/models/networks/default_LIF.py
@@ -31,7 +31,7 @@ class LIFNetwork(AbstractLIFNetwork):
         dW_ij = learning_rate * RPE * noise_i * (conductance_ij / synaptic_increment)
 
         The noise term is normalized by the desired noise standard deviation to decouple absolute noise levels from the magnitude of weight changes.
-        The weight updates are only applied to existing connections (weights != -inf).
+        The weight updates are only applied to existing connections (weights are not NaN).
 
         Args:
             t: Current time
@@ -70,6 +70,6 @@ class LIFNetwork(AbstractLIFNetwork):
         )  # Since W is in arbitrary units (not nS), scale G by synaptic increment to get a sensible scale
 
         dW = jnp.where(
-            state.W == -jnp.inf, 0.0, dW
+            jnp.isnan(state.W), 0.0, dW
         )  # No weight change for non-existing connections
         return dW

--- a/src/adaptive_SNN/models/networks/eligibility_LIF.py
+++ b/src/adaptive_SNN/models/networks/eligibility_LIF.py
@@ -77,6 +77,6 @@ class EligibilityLIFNetwork(AbstractLIFNetwork):
         dW = learning_rate * RPE * state.features.eligibility
 
         dW = jnp.where(
-            state.W == -jnp.inf, 0.0, dW
+            jnp.isnan(state.W), 0.0, dW
         )  # No weight change for non-existing connections
         return dW

--- a/src/adaptive_SNN/models/networks/gated_LIF.py
+++ b/src/adaptive_SNN/models/networks/gated_LIF.py
@@ -85,7 +85,7 @@ class GatedLIFNetwork(AbstractLIFNetwork):
         dW = learning_rate * RPE * state.features.eligibility
 
         dW = jnp.where(
-            state.W == -jnp.inf, 0.0, dW
+            jnp.isnan(state.W), 0.0, dW
         )  # No weight change for non-existing connections
         return dW
 

--- a/src/adaptive_SNN/simulation_configs/biofeedback_experiment.py
+++ b/src/adaptive_SNN/simulation_configs/biofeedback_experiment.py
@@ -51,13 +51,8 @@ def create_config(model_cls, N_neurons=100, key=jr.PRNGKey(0)) -> SimulationConf
             x.agent_state.noisy_network.network_state.S.astype(jnp.bool),
             x.agent_state.RPE.RPE.astype(jnp.float32),
             x.agent_state.noisy_network.network_state.W[0].astype(jnp.float32),
-            jnp.nanmean(
-                jnp.where(
-                    jnp.isfinite(x.agent_state.noisy_network.network_state.W),
-                    x.agent_state.noisy_network.network_state.W,
-                    jnp.nan,
-                )
-            ),
+            jnp.nanmean(x.agent_state.noisy_network.network_state.W),
+            x.environment_state.astype(jnp.float32),
         )
 
     save_at = SaveAt(steps=True, fn=save)

--- a/src/adaptive_SNN/simulation_configs/single_neuron_simulation.py
+++ b/src/adaptive_SNN/simulation_configs/single_neuron_simulation.py
@@ -32,7 +32,7 @@ def create_single_neuron_config_extra_synapse(
         [5000, 1250, 5]
     )  # High frequency background input and one moderate frequency input
     initial_weights = jnp.tile(
-        jnp.array([-jnp.inf] * N_neurons + [1.1, 11, 5.0]), (N_neurons, 1)
+        jnp.array([jnp.nan] * N_neurons + [1.1, 11, 5.0]), (N_neurons, 1)
     )
 
     key, spike_key, reward_noise_key = jr.split(key, 3)

--- a/src/adaptive_SNN/simulation_configs/single_synapse_learning.py
+++ b/src/adaptive_SNN/simulation_configs/single_synapse_learning.py
@@ -36,7 +36,7 @@ def create_default_config_single_synapse_task(
         [5000, 1250, 10]
     )  # High frequency background input and one moderate frequency input
     initial_weights = jnp.tile(
-        jnp.array([-jnp.inf] * N_neurons + [1.1, 11, 0.0]), (N_neurons, 1)
+        jnp.array([jnp.nan] * N_neurons + [1.1, 11, 0.0]), (N_neurons, 1)
     )
 
     key, spike_key, reward_noise_key = jr.split(key, 3)

--- a/src/adaptive_SNN/utils/metrics.py
+++ b/src/adaptive_SNN/utils/metrics.py
@@ -131,7 +131,7 @@ def compute_charge_ratio(t, state, model) -> Array:
     leak_conductance = base_network.leak_conductance
 
     dt = t[1] - t[0]
-    W = jnp.where(jnp.isfinite(W), W, 0.0)
+    W = jnp.where(~jnp.isnan(W), W, 0.0)
     weighed_G_inhibitory = (
         jnp.sum(W * G * jnp.invert(exc_mask[None, :]), axis=-1) + leak_conductance
     )

--- a/src/adaptive_SNN/visualization/api/plotting.py
+++ b/src/adaptive_SNN/visualization/api/plotting.py
@@ -556,8 +556,8 @@ def plot_weight_distribution_over_time(
             if neurons_to_plot is not None:
                 weight_data = weight_data[:, neurons_to_plot]
 
-            # Remove -inf values
-            weight_data = weight_data[jnp.isfinite(weight_data)]
+            # Remove NaN values
+            weight_data = weight_data[~jnp.isnan(weight_data)]
 
             all_weight_bins[i].append(weight_data.flatten())
 

--- a/src/adaptive_SNN/visualization/utils/components.py
+++ b/src/adaptive_SNN/visualization/utils/components.py
@@ -96,7 +96,7 @@ def _plot_conductances(
     network_state = get_LIF_state(sol.ys)
 
     N_neurons = base_network.N_neurons
-    W = jnp.where(~jnp.isfinite(network_state.W), 0.0, network_state.W)
+    W = jnp.where(jnp.isnan(network_state.W), 0.0, network_state.W)
     G = network_state.G
     exc_mask = base_network.excitatory_mask
 
@@ -410,7 +410,7 @@ def _plot_conductance_frequency_spectrum(
 ):
     lif_state = get_LIF_state(sol.ys)
     G = lif_state.G
-    W = jnp.where(~jnp.isfinite(lif_state.W), 0.0, lif_state.W)
+    W = jnp.where(jnp.isnan(lif_state.W), 0.0, lif_state.W)
 
     exc_mask = get_LIF_model(model).excitatory_mask
     weighed_G_excitatory = jnp.sum(W * G * exc_mask[None, :], axis=-1)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -612,7 +612,7 @@ def test_force_balance_no_change():
     state_after = model.force_balanced_weights(0, model.initial, args=args)
     balance_after = model.compute_balance(0, state_after, args=args)
     assert jnp.allclose(balance_after, balance)
-    assert jnp.allclose(state_after.W, state.W)
+    assert jnp.allclose(state_after.W, state.W, equal_nan=True)
 
 
 def test_force_balance_mini():
@@ -633,7 +633,7 @@ def test_force_balance_mini():
         get_desired_balance=lambda t, x, args: jnp.array([target_balance]),
     )
 
-    base_W = jnp.full((N_neurons, N_neurons + N_inputs), -jnp.inf)
+    base_W = jnp.full((N_neurons, N_neurons + N_inputs), jnp.nan)
     base_W = base_W.at[0, 1].set(1.0).at[0, 2].set(0.5).at[0, 3].set(1.0)
     state = make_baseline_state(model, W=base_W)
 
@@ -658,7 +658,7 @@ def test_force_balance_mini():
     )
 
     assert jnp.allclose(charge_I / charge_E, target_balance)
-    assert state.W[0][0] == -jnp.inf  # No self connection
+    assert jnp.isnan(state.W[0][0])  # No self connection
     assert state.W[0][1] == 1.0 and state.W[0][1] == 1.0  # Exc weights unchanged
 
 
@@ -708,7 +708,7 @@ def test_force_balance_zero_inhibitory_weight():
         get_desired_balance=lambda t, x, args: jnp.array([target_balance]),
     )
 
-    base_W = jnp.full((N_neurons, N_neurons + N_inputs), -jnp.inf)
+    base_W = jnp.full((N_neurons, N_neurons + N_inputs), jnp.nan)
     base_W = base_W.at[0, 1].set(1.0).at[0, 2].set(0.0).at[0, 3].set(1.0)
     state = make_baseline_state(model, W=base_W)
 
@@ -740,7 +740,7 @@ def test_force_balance_zero_inhibitory_weight_recurrent_only():
     excitatory_mask = jnp.array([True, True, False, False], dtype=bool)
     object.__setattr__(model, "excitatory_mask", excitatory_mask)
 
-    base_W = jnp.full((N_neurons, N_neurons + N_inputs), -jnp.inf)
+    base_W = jnp.full((N_neurons, N_neurons + N_inputs), jnp.nan)
     base_W = base_W.at[0, 1].set(1.0).at[0, 3].set(0.0)
     base_W = base_W.at[1, 0].set(1.0).at[1, 3].set(0.0)
     base_W = base_W.at[2, 1].set(1.0).at[2, 3].set(0.0)
@@ -775,7 +775,7 @@ def test_balance_simulated_input_counts():
         N_simulated_E_inputs=5,
     )
 
-    base_W = jnp.full((N_neurons, N_neurons + N_inputs), -jnp.inf)
+    base_W = jnp.full((N_neurons, N_neurons + N_inputs), jnp.nan)
     base_W = base_W.at[0, 1].set(1.0).at[0, 2].set(2.0).at[0, 3].set(3.0)
 
     state = make_baseline_state(model, W=base_W)
@@ -810,7 +810,7 @@ def test_synaptic_delays():
         model,
         V=voltages,
         W=jnp.fill_diagonal(
-            jnp.ones((N_neurons, N_neurons + N_inputs)), -jnp.inf, inplace=False
+            jnp.ones((N_neurons, N_neurons + N_inputs)), jnp.nan, inplace=False
         ),
     )  # Set some voltages above threshold to trigger spikes, set all w=1
     args = make_default_args(N_neurons, N_inputs)


### PR DESCRIPTION
This makes it easy to use e.g. jnp.nanmean to compute mean weights