### PR TITLE
[Draft — for evaluation] Per-synapse OUA graft + Tier-2 pattern discrimination

### DIFF
--- a/scripts/overnight/analyze_learning_and_tier2.py
+++ b/scripts/overnight/analyze_learning_and_tier2.py
@@ -1,0 +1,161 @@
+"""Analysis for Phase C (learning dynamics) and Phase E (Tier-2 patterns).
+
+Produces:
+- results/overnight-learning-dynamics/figure_W_trajectories.pdf
+- results/overnight-learning-dynamics/summary.csv
+- results/overnight-tier2-patterns/figure_readout_fr.pdf
+- results/overnight-tier2-patterns/summary.csv
+"""
+
+from __future__ import annotations
+
+import csv
+from collections import defaultdict
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+# --------------------------- Phase C: learning dynamics ----------------------
+def analyze_learning_dynamics():
+    raw = REPO / "results" / "overnight-learning-dynamics" / "raw"
+    out_dir = raw.parent
+    if not raw.exists() or not list(raw.glob("*.npz")):
+        print("[learning] no data in", raw)
+        return
+    files = sorted(raw.glob("*.npz"))
+    print(f"[learning] {len(files)} files")
+
+    rows = []
+    by_key = defaultdict(list)  # (cell, dV) -> list of (ts, W) trajectories
+    for fp in files:
+        z = np.load(fp, allow_pickle=True)
+        cell = str(z["cell_id"])
+        dV = float(z["delta_V"])
+        seed = int(z["seed"])
+        ts = z["ts"]
+        W = np.asarray(z["W_learn"]).ravel()
+        S = np.asarray(z["S"])
+        fr_n = float(S[:, 0].sum() / float(ts[-1]))
+        fr_c = float(S[:, 1].sum() / float(ts[-1]))
+        W_init = float(W[0]); W_final = float(W[-1])
+        dW_dt = (W_final - W_init) / float(ts[-1])
+        rows.append({
+            "cell": cell, "delta_V": dV, "dV_pow": int(round(np.log2(dV))), "seed": seed,
+            "W_init": W_init, "W_final": W_final, "dW_dt": dW_dt,
+            "fr_noisy": fr_n, "fr_clean": fr_c,
+        })
+        by_key[(cell, dV)].append((ts, W))
+
+    with open(out_dir / "summary.csv", "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+        w.writeheader(); w.writerows(rows)
+    print(f"[learning] wrote summary.csv ({len(rows)} rows)")
+
+    # Aggregate plot: W(t) per cell, mean across seeds + shading
+    cells = sorted({r["cell"] for r in rows})
+    dVs = sorted({r["delta_V"] for r in rows})
+
+    fig, axes = plt.subplots(len(dVs), len(cells), figsize=(2.0 * len(cells), 2.3 * len(dVs)), squeeze=False)
+    for i, dV in enumerate(dVs):
+        for j, cell in enumerate(cells):
+            ax = axes[i, j]
+            trajs = by_key.get((cell, dV), [])
+            if not trajs:
+                ax.text(0.5, 0.5, "no data", transform=ax.transAxes, ha="center")
+                continue
+            ts = trajs[0][0]
+            Ws = np.stack([w for _, w in trajs])
+            mean_W = np.mean(Ws, axis=0)
+            std_W = np.std(Ws, axis=0)
+            ax.plot(ts, mean_W, color="C0")
+            ax.fill_between(ts, mean_W - std_W, mean_W + std_W, alpha=0.2, color="C0")
+            ax.set_title(f"{cell} dV=2^{int(round(np.log2(dV)))}", fontsize=8)
+            ax.axhline(0, color="k", lw=0.3)
+            ax.grid(alpha=0.3)
+            if j == 0:
+                ax.set_ylabel("W_learnable")
+            if i == len(dVs) - 1:
+                ax.set_xlabel("time (s)")
+    fig.suptitle("Phase C — η > 0 closed-loop weight trajectories", fontsize=10)
+    fig.tight_layout(rect=(0, 0, 1, 0.96))
+    out = out_dir / "figure_W_trajectories.pdf"
+    fig.savefig(out, bbox_inches="tight")
+    plt.close(fig)
+    print(f"[learning] wrote {out}")
+
+
+# --------------------------- Phase E: Tier-2 -----------------------------------
+def analyze_tier2():
+    raw = REPO / "results" / "overnight-tier2-patterns" / "raw"
+    out_dir = raw.parent
+    if not raw.exists() or not list(raw.glob("*.npz")):
+        print("[tier2] no data in", raw)
+        return
+    files = sorted(raw.glob("*.npz"))
+    print(f"[tier2] {len(files)} files")
+
+    rows = []
+    by_cell = defaultdict(list)  # cell -> list of (ts, fr_readout, W_in)
+    for fp in files:
+        z = np.load(fp, allow_pickle=True)
+        cell = str(z["cell_id"])
+        ts = z["ts"]
+        fr = np.asarray(z["fr_readout"]).ravel()
+        W_in = np.asarray(z["W_readout_inputs"])  # (T, N_INPUTS)
+        npp = int(z["N_inputs"]) // int(z["n_patterns"])
+        # On-pattern (pattern 0) input weights mean
+        W_target_mean = W_in[:, :npp].mean(axis=1)
+        W_off_mean = W_in[:, npp:].mean(axis=1)
+        rows.append({
+            "cell": cell, "seed": int(z["seed"]),
+            "fr_readout_init": float(fr[:50].mean()),
+            "fr_readout_final": float(fr[-50:].mean()),
+            "W_target_init": float(W_target_mean[0]),
+            "W_target_final": float(W_target_mean[-1]),
+            "W_off_init": float(W_off_mean[0]),
+            "W_off_final": float(W_off_mean[-1]),
+            "selectivity_final": float(W_target_mean[-1] - W_off_mean[-1]),
+        })
+        by_cell[cell].append((ts, fr, W_target_mean, W_off_mean))
+
+    with open(out_dir / "summary.csv", "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+        w.writeheader(); w.writerows(rows)
+    print(f"[tier2] wrote summary.csv ({len(rows)} rows)")
+
+    cells = sorted(by_cell.keys())
+    fig, axes = plt.subplots(2, len(cells), figsize=(3 * len(cells), 5), squeeze=False)
+    for j, cell in enumerate(cells):
+        ax0 = axes[0, j]
+        ax1 = axes[1, j]
+        for ts, fr, Wt, Wo in by_cell[cell]:
+            ax0.plot(ts, fr, alpha=0.6)
+            ax1.plot(ts, Wt, color="C2", alpha=0.6, label="W_target")
+            ax1.plot(ts, Wo, color="C1", alpha=0.6, label="W_off-pattern")
+        ax0.set_title(f"{cell} — readout fr")
+        ax0.set_ylabel("Hz")
+        ax0.grid(alpha=0.3)
+        ax1.set_title(f"{cell} — input weight selectivity")
+        ax1.set_xlabel("time (s)")
+        ax1.set_ylabel("W")
+        ax1.grid(alpha=0.3)
+        if j == 0:
+            ax1.legend(["target", "off"], fontsize=7)
+    fig.suptitle("Phase E — Tier-2 pattern discrimination", fontsize=10)
+    fig.tight_layout(rect=(0, 0, 1, 0.94))
+    out = out_dir / "figure_tier2.pdf"
+    fig.savefig(out, bbox_inches="tight")
+    plt.close(fig)
+    print(f"[tier2] wrote {out}")
+
+
+if __name__ == "__main__":
+    analyze_learning_dynamics()
+    analyze_tier2()

--- a/scripts/overnight/analyze_v2.py
+++ b/scripts/overnight/analyze_v2.py
@@ -1,0 +1,337 @@
+"""Analysis for run_paired_comparison_v2 outputs.
+
+Implements Alexander Eqs. 33 and 34 properly:
+  rho(cell, dV, seed) = ∫ e(t) δ_r^task(t) dt / ∫ |e(t) δ_r^task(t)| dt
+  SNR(cell, dV, seed) = ∫ e(t) δ_r^task(t) dt / ∫ |e(t) δ_r^noise(t)| dt
+
+where:
+  e(t)       = eligibility (saved for B cells; reconstructed offline for A cells
+               as instantaneous OUA excursion ζ * s * γ).
+  δ_r^task   = exp-filter(spike_noisy - spike_noiseless, τ=100ms).
+  δ_r^noise  = exp-filter(Poisson(1 Hz, unit jumps), τ=100ms), generated from
+               a seeded reproducible draw.
+
+Also computes:
+  - firing rates (noisy / noiseless), V mean & variance, γ-engagement
+  - paired statistics across (PN, PS) twins at matched seed
+  - paired CSVs and a headline figure
+
+Outputs go to results/overnight-single-synapse-v2/.
+"""
+
+from __future__ import annotations
+
+import csv
+from collections import defaultdict
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[2]
+RESULTS = REPO / "results" / "overnight-single-synapse-v2"
+RAW = RESULTS / "raw"
+
+# Task constants — must match run_paired_comparison_v2.py
+TAU_RPE = 0.1
+W0 = 1e-9
+E_E = 0.0
+V_TH = -50e-3
+V_REST = -70e-3
+WARMUP_T = 10.0
+RPE_NOISE_RATE = 1.0   # Hz
+RPE_NOISE_STD = 1.0    # jump std
+
+CELLS = ["A-PN", "A-PS", "A0-PN", "A0-PS", "B-PN", "B-PS"]
+PAIRS = {
+    "A": ("A-PN", "A-PS"),
+    "A0": ("A0-PN", "A0-PS"),
+    "B": ("B-PN", "B-PS"),
+}
+
+
+def _voltage_gate(V, delta_V):
+    default_area = (V_TH - V_REST)
+    driving_force = E_E - V
+    integral = lambda V_: (E_E + delta_V - V_) * -np.exp((V_ - V_TH) / delta_V)
+    area = integral(V_REST) - integral(V_TH)
+    return (driving_force / delta_V * np.exp((V - V_TH) / delta_V)) / (area / default_area)
+
+
+def _exp_filter(x, dt, tau):
+    """Discrete-time exponential filter approximation of dy/dt = (-y + x)/tau."""
+    alpha = np.exp(-dt / tau)
+    y = np.zeros_like(x, dtype=float)
+    for i in range(1, len(x)):
+        y[i] = y[i - 1] * alpha + x[i] * (1 - alpha)
+    return y
+
+
+def _rpe_task(ts, S_noisy, S_noiseless, tau=TAU_RPE):
+    """Eq. 5.2 — δ_r^task = sign(S0 - S1), filtered."""
+    raw = (S_noisy > 0).astype(float) - (S_noiseless > 0).astype(float)
+    dt = float(ts[1] - ts[0])
+    return _exp_filter(raw, dt, tau)
+
+
+def _rpe_noise(ts, seed, rate=RPE_NOISE_RATE, std=RPE_NOISE_STD, tau=TAU_RPE):
+    """Independent Poisson-jump 'reward noise' process per Eq. 5.3.
+
+    Implemented offline: at each timestep, draw a Poisson jump count with
+    probability rate*dt; jumps are Gaussian with std=1.0; filter with τ_RPE.
+    Reproducible from the seed.
+    """
+    rng = np.random.default_rng(seed * 10007 + 1)  # decorrelate from spike seed
+    dt = float(ts[1] - ts[0])
+    n_jumps_per_step = rng.poisson(rate * dt, size=len(ts))
+    jump_signs = rng.normal(0.0, std, size=len(ts))
+    raw = n_jumps_per_step.astype(float) * jump_signs
+    return _exp_filter(raw, dt, tau)
+
+
+def _eligibility_oua(z_learn, G_learn, V_noisy, delta_V, use_gate):
+    """OUA's instantaneous eligibility-equivalent at the learnable synapse.
+
+    e_ij(t) = ζ_ij(t) * s_ij(t) * γ(V_i(t))   (τ_e → 0 limit, multiplicative-on-weight)
+    With s = G / w0; γ = 1 when use_gate is False.
+    """
+    s_learn = G_learn / W0
+    if use_gate:
+        gate = _voltage_gate(V_noisy, delta_V)
+    else:
+        gate = np.ones_like(V_noisy)
+    return z_learn * s_learn * gate
+
+
+def _compute_metrics(path):
+    z = np.load(path, allow_pickle=True)
+    ts = z["ts"]
+    S = z["S"]
+    V = z["V"]
+    G_learn = np.asarray(z["G_learnable"]).ravel()
+    noise = z["noise_state"]
+    cell_id = str(z["cell_id"])
+    delta_V = float(z["delta_V"])
+    seed = int(z["seed"])
+
+    # Reconstruct eligibility e(t).
+    if cell_id.startswith("B-"):
+        e = np.asarray(z["eligibility_learnable"]).ravel()
+    else:
+        use_gate = cell_id in ("A-PN", "A-PS")
+        if noise.ndim == 2:
+            # per-neuron noise broadcast: zeta_i for noisy neuron is noise[:, 0]
+            # in per-neuron geometry the learnable synapse receives the per-neuron
+            # excursion directly (alpha=0 endpoint, no |E_i| scaling here because
+            # we treat the per-neuron noise as the perturbation seen at this
+            # synapse — variance match handled separately in calibration).
+            zeta_at_learn = noise[:, 0]
+            sigma_norm = float(z["sigma_pn"])
+        else:
+            zeta_at_learn = noise[:, 0, 4]
+            sigma_norm = float(z["sigma_ps"])
+        # Normalise zeta by sigma so the eligibility is dimensionless O(1)
+        # (matches the existing repo convention noise/noise_std in eligibility_LIF).
+        zeta_rel = zeta_at_learn / max(sigma_norm, 1e-30)
+        # Convert G to s (dimensionless) since W is dimensionless in repo
+        e = _eligibility_oua(zeta_rel, G_learn, V[:, 0], delta_V, use_gate)
+
+    # δ_r task and noise
+    rpe_task = _rpe_task(ts, S[:, 0], S[:, 1])
+    rpe_noise = _rpe_noise(ts, seed)
+
+    # Apply steady-state mask
+    ss = ts > WARMUP_T
+    e_ss = e[ss]
+    rt = rpe_task[ss]
+    rn = rpe_noise[ss]
+
+    # Eq. 33 and 34
+    num = float(np.trapezoid(e_ss * rt, ts[ss]))
+    denom_rho = float(np.trapezoid(np.abs(e_ss * rt), ts[ss]))
+    denom_snr = float(np.trapezoid(np.abs(e_ss * rn), ts[ss]))
+    rho = num / denom_rho if denom_rho > 1e-30 else 0.0
+    snr = num / denom_snr if denom_snr > 1e-30 else 0.0
+
+    # Additional sanity metrics
+    fr_n = float(S[ss, 0].sum() / (ts[ss][-1] - ts[ss][0]))
+    fr_c = float(S[ss, 1].sum() / (ts[ss][-1] - ts[ss][0]))
+    v_mean = float(V[ss, 0].mean())
+    v_var = float(V[ss, 0].var())
+    rpe_task_var = float(np.var(rt))
+    rpe_noise_var = float(np.var(rn))
+    elig_var = float(np.var(e_ss))
+
+    return {
+        "cell_id": cell_id,
+        "delta_V": delta_V,
+        "dV_pow": int(round(np.log2(delta_V))),
+        "seed": seed,
+        "rho": rho,
+        "snr": snr,
+        "fr_noisy": fr_n,
+        "fr_clean": fr_c,
+        "v_mean_noisy": v_mean,
+        "v_var_noisy": v_var,
+        "rpe_task_var": rpe_task_var,
+        "rpe_noise_var": rpe_noise_var,
+        "elig_var": elig_var,
+        "num_e_rtask": num,
+    }
+
+
+def main():
+    files = sorted(RAW.glob("*.npz"))
+    print(f"[analyze] {len(files)} raw files")
+    if not files:
+        return
+
+    rows = []
+    for fp in files:
+        try:
+            rows.append(_compute_metrics(fp))
+        except Exception as e:
+            print(f"  [skip] {fp.name}: {type(e).__name__}: {str(e)[:100]}")
+
+    with open(RESULTS / "summary.csv", "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+        w.writeheader()
+        w.writerows(rows)
+    print(f"[analyze] summary.csv ({len(rows)} rows)")
+
+    # Paired CSV
+    idx = defaultdict(list)
+    for r in rows:
+        idx[(r["cell_id"], r["delta_V"])].append(r)
+    dV_vals = sorted({r["delta_V"] for r in rows})
+    paired_rows = []
+    for pair_id, (pn, ps) in PAIRS.items():
+        for dV in dV_vals:
+            pns = idx.get((pn, dV), [])
+            pss = idx.get((ps, dV), [])
+            common = sorted({r["seed"] for r in pns} & {r["seed"] for r in pss})
+            for s in common:
+                pr = next(r for r in pns if r["seed"] == s)
+                pp = next(r for r in pss if r["seed"] == s)
+                paired_rows.append({
+                    "pair": pair_id,
+                    "delta_V": dV,
+                    "dV_pow": int(round(np.log2(dV))),
+                    "seed": s,
+                    "rho_PN": pr["rho"],
+                    "rho_PS": pp["rho"],
+                    "diff_rho": pp["rho"] - pr["rho"],
+                    "snr_PN": pr["snr"],
+                    "snr_PS": pp["snr"],
+                    "log10_ratio_SNR": (
+                        np.log10(abs(pp["snr"]) + 1e-30)
+                        - np.log10(abs(pr["snr"]) + 1e-30)
+                    ),
+                    "fr_PN": pr["fr_noisy"],
+                    "fr_PS": pp["fr_noisy"],
+                })
+    if paired_rows:
+        with open(RESULTS / "paired_summary.csv", "w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=list(paired_rows[0].keys()))
+            w.writeheader()
+            w.writerows(paired_rows)
+        print(f"[analyze] paired_summary.csv ({len(paired_rows)} rows)")
+
+    # Headline plot: 6 cells × dV with rho and SNR overlays
+    def _agg(cell, dV, key):
+        vs = [r[key] for r in idx.get((cell, dV), [])]
+        if not vs:
+            return np.nan, np.nan
+        return float(np.mean(vs)), float(np.std(vs) / np.sqrt(max(len(vs), 1)))
+
+    dV_arr = np.array(dV_vals)
+    dV_log2 = np.log2(dV_arr)
+
+    fig, axes = plt.subplots(2, 3, figsize=(13, 7), sharex=True)
+    cell_order = ["A-PN", "B-PN", "A0-PN", "A-PS", "B-PS", "A0-PS"]
+    titles = {
+        "A-PN": "A-PN  (per-neuron OUA, gate ON, HEADLINE)",
+        "A-PS": "A-PS  (per-synapse OUA, gate ON, HEADLINE)",
+        "A0-PN": "A0-PN (per-neuron OUA, gate OFF, control)",
+        "A0-PS": "A0-PS (per-synapse OUA, gate OFF, control)",
+        "B-PN": "B-PN  (per-neuron Elig, gate ON — Alexander)",
+        "B-PS": "B-PS  (per-synapse Elig, gate ON, co-headline)",
+    }
+    for ax, cell in zip(axes.ravel(), cell_order):
+        means_rho = [_agg(cell, dV, "rho")[0] for dV in dV_vals]
+        sems_rho = [_agg(cell, dV, "rho")[1] for dV in dV_vals]
+        means_snr = [_agg(cell, dV, "snr")[0] for dV in dV_vals]
+        sems_snr = [_agg(cell, dV, "snr")[1] for dV in dV_vals]
+        ax.errorbar(dV_log2, means_rho, yerr=sems_rho, fmt="o-", color="C0", label=r"$\rho$ (Eq.33)")
+        ax2 = ax.twinx()
+        ax2.errorbar(dV_log2, means_snr, yerr=sems_snr, fmt="s--", color="C3", label="SNR (Eq.34)")
+        ax.set_title(titles.get(cell, cell), fontsize=9)
+        ax.set_xlabel("log2(ΔV)")
+        ax.set_ylabel(r"$\rho$", color="C0")
+        ax2.set_ylabel("SNR", color="C3")
+        ax.axhline(0, color="k", lw=0.5)
+        ax.grid(alpha=0.3)
+        ax.set_ylim(-1.2, 1.2)
+    fig.suptitle(
+        "Single Synapse Task — gradient alignment ρ (Eq. 33) and SNR (Eq. 34)\n"
+        f"6 cells, 7 ΔV × 5 seeds (η=0, T=60s, noise_scale=2.0, balance=0.0)",
+        fontsize=10,
+    )
+    fig.tight_layout(rect=(0, 0, 1, 0.94))
+    out = RESULTS / "figure_v2_6cell_rho_snr.pdf"
+    fig.savefig(out, bbox_inches="tight")
+    plt.close(fig)
+    print(f"[analyze] {out}")
+
+    # Paired comparison panel
+    fig, axes = plt.subplots(2, 3, figsize=(13, 6), sharex=True)
+    for col, (pair_id, (pn, ps)) in enumerate(PAIRS.items()):
+        # row 0: paired difference of rho
+        diffs_mean = []
+        diffs_sem = []
+        for dV in dV_vals:
+            ds = [r["diff_rho"] for r in paired_rows if r["pair"] == pair_id and r["delta_V"] == dV]
+            if ds:
+                diffs_mean.append(float(np.mean(ds)))
+                diffs_sem.append(float(np.std(ds) / np.sqrt(len(ds))))
+            else:
+                diffs_mean.append(np.nan)
+                diffs_sem.append(np.nan)
+        ax = axes[0, col]
+        ax.errorbar(dV_log2, diffs_mean, yerr=diffs_sem, fmt="o-", color="C2")
+        ax.axhline(0, color="k", lw=0.5)
+        ax.set_title(f"Pair {pair_id}: ρ(PS) − ρ(PN)")
+        ax.set_ylabel("Δρ")
+        ax.grid(alpha=0.3)
+
+        # row 1: log10(SNR_PS / SNR_PN)
+        rs_mean = []
+        rs_sem = []
+        for dV in dV_vals:
+            rs = [r["log10_ratio_SNR"] for r in paired_rows if r["pair"] == pair_id and r["delta_V"] == dV]
+            if rs:
+                rs_mean.append(float(np.mean(rs)))
+                rs_sem.append(float(np.std(rs) / np.sqrt(len(rs))))
+            else:
+                rs_mean.append(np.nan)
+                rs_sem.append(np.nan)
+        ax = axes[1, col]
+        ax.errorbar(dV_log2, rs_mean, yerr=rs_sem, fmt="o-", color="C4")
+        ax.axhline(0, color="k", lw=0.5)
+        ax.set_title(f"Pair {pair_id}: log10(SNR_PS / SNR_PN)")
+        ax.set_xlabel("log2(ΔV)")
+        ax.set_ylabel("log10 ratio")
+        ax.grid(alpha=0.3)
+    fig.suptitle("Paired per-neuron vs per-synapse comparison (matched seed)", fontsize=10)
+    fig.tight_layout(rect=(0, 0, 1, 0.94))
+    out2 = RESULTS / "figure_v2_paired.pdf"
+    fig.savefig(out2, bbox_inches="tight")
+    plt.close(fig)
+    print(f"[analyze] {out2}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/overnight/plot_paired_comparison.py
+++ b/scripts/overnight/plot_paired_comparison.py
@@ -1,0 +1,298 @@
+"""Paired 4-cell comparison figure for the Single Synapse Task.
+
+Loads results/overnight-single-synapse/raw/*.npz and produces:
+- summary.csv (per (cell, dV, seed))
+- paired_summary.csv (per (pair, dV, seed))
+- figure_paired_comparison.pdf (2x2 grid + paired-difference + paired-ratio rows)
+- figure_alexander_replication.pdf (B-PN replication, side-by-side rho/SNR vs dV)
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[2]
+RESULTS = REPO / "results" / "overnight-single-synapse"
+RAW = RESULTS / "raw"
+
+CELLS = ["A-PN", "A-PS", "B-PN", "B-PS"]
+PAIRS = {"A": ("A-PN", "A-PS"), "B": ("B-PN", "B-PS")}
+DV_POWS = list(range(-13, -6))  # -13..-7 inclusive (7 values)
+SEEDS = [42, 43, 44, 45, 46]
+DT = 1e-4
+WARMUP_T = 5.0
+TAU_RPE = 0.1
+
+
+def _approx_rpe_from_spikes(ts, S, tau=TAU_RPE):
+    """Exponentially decaying RPE proxy from instantaneous spike difference."""
+    raw = S[:, 0] - S[:, 1]
+    alpha = np.exp(-(ts[1] - ts[0]) / tau)
+    rpe = np.zeros_like(raw, dtype=float)
+    for i in range(1, len(raw)):
+        rpe[i] = rpe[i - 1] * alpha + raw[i] * (1 - alpha)
+    return rpe
+
+
+def _compute_metrics(raw_path):
+    """Compute rho and SNR for one raw npz file."""
+    z = np.load(raw_path, allow_pickle=True)
+    ts = z["ts"]
+    S = z["S"]
+    V = z["V"]
+    G_learn = np.asarray(z["G_learn"]).ravel()
+    noise = z["noise"]
+    cell_id = str(z["cell_id"])
+
+    # Steady-state mask
+    ss = ts > WARMUP_T
+
+    # RPE proxy from saved spikes
+    rpe = _approx_rpe_from_spikes(ts, S)
+    rpe_ss = rpe[ss]
+
+    # Build the per-step gradient signal for the LEARNABLE synapse
+    # (neuron 0, input 2 -> column 4 in the W matrix).
+    # OUA: g_step = lr * rpe * (zeta / sigma_E) * (G_learn / w0) * gate
+    # Eligibility: g_step = rpe * eligibility
+    # We set lr = 1 (eta=0 means we measure the gradient signal directly).
+    if cell_id.startswith("A-"):
+        # noise here is the per-neuron OU (B-PN style) for A-PN or 2D for A-PS
+        # We saved noise as the noise_state of the noisy wrapper.
+        if noise.ndim == 2:
+            # per-neuron noise: shape (T, N_neurons)
+            zeta_at_learnable = noise[:, 0]  # noisy neuron's per-neuron noise
+            sigma = float(z["sigma_pn"]) if "sigma_pn" in z.files else 1.0
+        else:
+            # per-synapse noise: shape (T, N_neurons, N+N_in)
+            zeta_at_learnable = noise[:, 0, 4]
+            sigma = float(z["sigma_ps"]) if "sigma_ps" in z.files else 1.0
+        # G_learn already (T,) — convert to s via 1/w0 = 1e9 (synaptic_increment = 1nS)
+        s_learn = G_learn / 1e-9
+        # Use gate proxy = 1 here (we did not save gate values); rho/SNR computed
+        # on the un-gated gradient kernel is still informative for comparisons.
+        signal = rpe * (zeta_at_learnable / max(sigma, 1e-30)) * s_learn
+    else:
+        # Eligibility cells: saved eligibility_learnable (T,)
+        elig = z["eligibility_learnable"].ravel()
+        signal = rpe * elig
+
+    signal_ss = signal[ss]
+    # Gradient alignment proxy: sign of the time-averaged signal vs the
+    # expected positive gradient (for SST, the noiseless twin firing more
+    # than the noisy neuron when the synapse is strong enough). The true
+    # sign of d<R>/dW for the learnable synapse is positive by construction:
+    # increasing W -> more excitation -> noisy neuron fires more -> closer to
+    # noiseless twin baseline. We define rho = sign(mean(signal)) for the
+    # cell at non-zero seed magnitudes.
+    mean_sig = float(np.mean(signal_ss))
+    std_sig = float(np.std(signal_ss))
+    rho_proxy = mean_sig / (np.abs(mean_sig) + 1e-30)  # +/- 1 sign
+    snr_proxy = np.abs(mean_sig) / (std_sig + 1e-30)
+
+    fr_noisy = float(S[ss, 0].sum() / ((ts[ss][-1] - ts[ss][0]) if ss.any() else 1))
+    fr_clean = float(S[ss, 1].sum() / ((ts[ss][-1] - ts[ss][0]) if ss.any() else 1))
+    v_mean_noisy = float(V[ss, 0].mean())
+    v_var_noisy = float(V[ss, 0].var())
+
+    return {
+        "cell_id": cell_id,
+        "delta_V": float(z["delta_V"]),
+        "seed": int(z["seed"]),
+        "rho": rho_proxy,
+        "snr": snr_proxy,
+        "mean_sig": mean_sig,
+        "std_sig": std_sig,
+        "fr_noisy": fr_noisy,
+        "fr_clean": fr_clean,
+        "v_mean_noisy": v_mean_noisy,
+        "v_var_noisy": v_var_noisy,
+    }
+
+
+def main():
+    if not RAW.exists():
+        print(f"[ERROR] no raw directory at {RAW}")
+        return
+
+    rows = []
+    files = sorted(RAW.glob("*.npz"))
+    print(f"[plot] processing {len(files)} files")
+    for fp in files:
+        try:
+            rows.append(_compute_metrics(fp))
+        except Exception as exc:
+            print(f"  [skip] {fp.name}: {exc}")
+
+    if not rows:
+        print("[plot] no rows; abort")
+        return
+
+    # Write summary CSV
+    with open(RESULTS / "summary.csv", "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+    print(f"[plot] wrote summary.csv with {len(rows)} rows")
+
+    # Index: dict[(cell, dV)] -> list[row]
+    idx = {}
+    for r in rows:
+        idx.setdefault((r["cell_id"], r["delta_V"]), []).append(r)
+    dV_vals = sorted({r["delta_V"] for r in rows})
+
+    # Paired summary
+    paired_rows = []
+    for pair_id, (pn, ps) in PAIRS.items():
+        for dV in dV_vals:
+            pn_rows = idx.get((pn, dV), [])
+            ps_rows = idx.get((ps, dV), [])
+            seeds_common = sorted(
+                {r["seed"] for r in pn_rows} & {r["seed"] for r in ps_rows}
+            )
+            for s in seeds_common:
+                pn_r = next(r for r in pn_rows if r["seed"] == s)
+                ps_r = next(r for r in ps_rows if r["seed"] == s)
+                paired_rows.append({
+                    "pair": pair_id,
+                    "delta_V": dV,
+                    "seed": s,
+                    "rho_PN": pn_r["rho"],
+                    "rho_PS": ps_r["rho"],
+                    "diff_rho": ps_r["rho"] - pn_r["rho"],
+                    "snr_PN": pn_r["snr"],
+                    "snr_PS": ps_r["snr"],
+                    "ratio_snr_PS_PN": ps_r["snr"] / (pn_r["snr"] + 1e-30),
+                })
+    if paired_rows:
+        with open(RESULTS / "paired_summary.csv", "w", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=list(paired_rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(paired_rows)
+        print(f"[plot] wrote paired_summary.csv with {len(paired_rows)} rows")
+
+    # ---- Headline figure: 2x2 + paired-difference + paired-ratio ----
+    dV_vals_arr = np.array(dV_vals)
+    dV_log2 = np.log2(dV_vals_arr)
+
+    fig, axes = plt.subplots(4, 2, figsize=(9, 12), sharex="col")
+
+    panel_titles = {
+        ("A-PN", "rho"): "A-PN (per-neuron OUA): rho",
+        ("A-PS", "rho"): "A-PS (per-synapse OUA, headline): rho",
+        ("B-PN", "rho"): "B-PN (per-neuron Elig, Alexander): rho",
+        ("B-PS", "rho"): "B-PS (per-synapse Elig, co-headline): rho",
+    }
+
+    def _agg(cell, dV, key):
+        vals = [r[key] for r in idx.get((cell, dV), [])]
+        if not vals:
+            return np.nan, np.nan
+        return float(np.mean(vals)), float(np.std(vals) / np.sqrt(max(len(vals), 1)))
+
+    # Top 2x2: rho + SNR bars per cell
+    for col, cell_col in enumerate([("A-PN", "B-PN"), ("A-PS", "B-PS")]):
+        for row, cell in enumerate(cell_col):
+            ax = axes[row, col]
+            means_rho = [_agg(cell, dV, "rho")[0] for dV in dV_vals]
+            sems_rho = [_agg(cell, dV, "rho")[1] for dV in dV_vals]
+            means_snr = [_agg(cell, dV, "snr")[0] for dV in dV_vals]
+            sems_snr = [_agg(cell, dV, "snr")[1] for dV in dV_vals]
+            ax2 = ax.twinx()
+            ax.errorbar(dV_log2, means_rho, yerr=sems_rho, fmt="o-", color="C0", label="rho")
+            ax2.errorbar(dV_log2, means_snr, yerr=sems_snr, fmt="s--", color="C3", label="SNR")
+            ax.set_title(cell)
+            ax.set_ylabel("rho", color="C0")
+            ax2.set_ylabel("SNR", color="C3")
+            ax.set_ylim(-1.2, 1.2)
+            ax2.set_yscale("log")
+            ax.axhline(0, color="k", lw=0.5)
+            ax.grid(alpha=0.3)
+
+    # Bottom rows: paired statistics (PS - PN difference, PS/PN ratio)
+    for col, pair_id in enumerate(["A", "B"]):
+        pn_cell, ps_cell = PAIRS[pair_id]
+        # Paired difference of rho
+        ax = axes[2, col]
+        diffs_mean = []
+        diffs_sem = []
+        for dV in dV_vals:
+            paired_for_dv = [
+                r for r in paired_rows if r["pair"] == pair_id and r["delta_V"] == dV
+            ]
+            if paired_for_dv:
+                d = np.array([r["diff_rho"] for r in paired_for_dv])
+                diffs_mean.append(d.mean())
+                diffs_sem.append(d.std() / np.sqrt(len(d)))
+            else:
+                diffs_mean.append(np.nan)
+                diffs_sem.append(np.nan)
+        ax.errorbar(dV_log2, diffs_mean, yerr=diffs_sem, fmt="o-", color="C2")
+        ax.axhline(0, color="k", lw=0.5)
+        ax.set_title(f"Pair {pair_id}: PS - PN rho difference")
+        ax.set_ylabel("Delta rho (PS - PN)")
+        ax.grid(alpha=0.3)
+
+        # Paired SNR ratio
+        ax = axes[3, col]
+        ratios_mean = []
+        ratios_sem = []
+        for dV in dV_vals:
+            paired_for_dv = [
+                r for r in paired_rows if r["pair"] == pair_id and r["delta_V"] == dV
+            ]
+            if paired_for_dv:
+                r_arr = np.array([np.log10(r["ratio_snr_PS_PN"] + 1e-30) for r in paired_for_dv])
+                ratios_mean.append(r_arr.mean())
+                ratios_sem.append(r_arr.std() / np.sqrt(len(r_arr)))
+            else:
+                ratios_mean.append(np.nan)
+                ratios_sem.append(np.nan)
+        ax.errorbar(dV_log2, ratios_mean, yerr=ratios_sem, fmt="o-", color="C4")
+        ax.axhline(0, color="k", lw=0.5)
+        ax.set_title(f"Pair {pair_id}: log10(SNR_PS / SNR_PN)")
+        ax.set_ylabel("log10(SNR_PS / SNR_PN)")
+        ax.set_xlabel("log2(Delta_V) [V]")
+        ax.grid(alpha=0.3)
+
+    fig.suptitle("Paired 4-cell comparison: Single Synapse Task (eta=0)", fontsize=12)
+    fig.tight_layout(rect=(0, 0, 1, 0.97))
+    out = RESULTS / "figure_paired_comparison.pdf"
+    fig.savefig(out, bbox_inches="tight")
+    print(f"[plot] wrote {out}")
+
+    # ---- Supporting: Alexander replication (B-PN cell) ----
+    fig2, ax = plt.subplots(1, 2, figsize=(7, 3.2))
+    means_rho = [_agg("B-PN", dV, "rho")[0] for dV in dV_vals]
+    sems_rho = [_agg("B-PN", dV, "rho")[1] for dV in dV_vals]
+    means_snr = [_agg("B-PN", dV, "snr")[0] for dV in dV_vals]
+    sems_snr = [_agg("B-PN", dV, "snr")[1] for dV in dV_vals]
+    ax[0].errorbar(dV_log2, means_rho, yerr=sems_rho, fmt="o-", color="C0")
+    ax[0].set_title("B-PN replication: rho vs Delta_V")
+    ax[0].set_xlabel("log2(Delta_V) [V]")
+    ax[0].set_ylabel("rho")
+    ax[0].axhline(0, color="k", lw=0.5)
+    ax[0].set_ylim(-1.2, 1.2)
+    ax[0].grid(alpha=0.3)
+
+    ax[1].errorbar(dV_log2, means_snr, yerr=sems_snr, fmt="o-", color="C3")
+    ax[1].set_title("B-PN replication: SNR vs Delta_V")
+    ax[1].set_xlabel("log2(Delta_V) [V]")
+    ax[1].set_ylabel("SNR")
+    ax[1].set_yscale("log")
+    ax[1].grid(alpha=0.3)
+    fig2.tight_layout()
+    out2 = RESULTS / "figure_alexander_replication.pdf"
+    fig2.savefig(out2, bbox_inches="tight")
+    print(f"[plot] wrote {out2}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/overnight/plot_paired_comparison.py
+++ b/scripts/overnight/plot_paired_comparison.py
@@ -41,6 +41,16 @@ def _approx_rpe_from_spikes(ts, S, tau=TAU_RPE):
     return rpe
 
 
+def _voltage_gate_offline(V, delta_V, E_E=0.0, V_th=-50e-3, V_rest=-70e-3):
+    """Replicates _gating.voltage_gate on saved V trajectory."""
+    default_area = (V_th - V_rest)
+    driving_force = E_E - V
+    integral = lambda V_: (E_E + delta_V - V_) * -np.exp((V_ - V_th) / delta_V)
+    area = integral(V_rest) - integral(V_th)
+    gating = driving_force / delta_V * np.exp((V - V_th) / delta_V)
+    return gating / (area / default_area)
+
+
 def _compute_metrics(raw_path):
     """Compute rho and SNR for one raw npz file."""
     z = np.load(raw_path, allow_pickle=True)
@@ -50,6 +60,7 @@ def _compute_metrics(raw_path):
     G_learn = np.asarray(z["G_learn"]).ravel()
     noise = z["noise"]
     cell_id = str(z["cell_id"])
+    delta_V = float(z["delta_V"])
 
     # Steady-state mask
     ss = ts > WARMUP_T
@@ -58,27 +69,26 @@ def _compute_metrics(raw_path):
     rpe = _approx_rpe_from_spikes(ts, S)
     rpe_ss = rpe[ss]
 
+    # Gate at the noisy neuron (offline replica of training-time gate).
+    gate_noisy = _voltage_gate_offline(V[:, 0], delta_V)
+
     # Build the per-step gradient signal for the LEARNABLE synapse
     # (neuron 0, input 2 -> column 4 in the W matrix).
     # OUA: g_step = lr * rpe * (zeta / sigma_E) * (G_learn / w0) * gate
     # Eligibility: g_step = rpe * eligibility
     # We set lr = 1 (eta=0 means we measure the gradient signal directly).
     if cell_id.startswith("A-"):
-        # noise here is the per-neuron OU (B-PN style) for A-PN or 2D for A-PS
-        # We saved noise as the noise_state of the noisy wrapper.
+        # OUA: dW_ij = lr * RPE * (zeta_ij / sigma_E) * (G_ij / w0) * gate(V_i)
         if noise.ndim == 2:
             # per-neuron noise: shape (T, N_neurons)
-            zeta_at_learnable = noise[:, 0]  # noisy neuron's per-neuron noise
+            zeta_at_learnable = noise[:, 0]
             sigma = float(z["sigma_pn"]) if "sigma_pn" in z.files else 1.0
         else:
             # per-synapse noise: shape (T, N_neurons, N+N_in)
             zeta_at_learnable = noise[:, 0, 4]
             sigma = float(z["sigma_ps"]) if "sigma_ps" in z.files else 1.0
-        # G_learn already (T,) — convert to s via 1/w0 = 1e9 (synaptic_increment = 1nS)
         s_learn = G_learn / 1e-9
-        # Use gate proxy = 1 here (we did not save gate values); rho/SNR computed
-        # on the un-gated gradient kernel is still informative for comparisons.
-        signal = rpe * (zeta_at_learnable / max(sigma, 1e-30)) * s_learn
+        signal = rpe * (zeta_at_learnable / max(sigma, 1e-30)) * s_learn * gate_noisy
     else:
         # Eligibility cells: saved eligibility_learnable (T,)
         elig = z["eligibility_learnable"].ravel()

--- a/scripts/overnight/plot_paired_comparison.py
+++ b/scripts/overnight/plot_paired_comparison.py
@@ -207,12 +207,20 @@ def main():
             sems_snr = [_agg(cell, dV, "snr")[1] for dV in dV_vals]
             ax2 = ax.twinx()
             ax.errorbar(dV_log2, means_rho, yerr=sems_rho, fmt="o-", color="C0", label="rho")
-            ax2.errorbar(dV_log2, means_snr, yerr=sems_snr, fmt="s--", color="C3", label="SNR")
+            ax2.errorbar(
+                dV_log2,
+                np.maximum(np.array(means_snr), 1e-6),
+                yerr=sems_snr,
+                fmt="s--",
+                color="C3",
+                label="SNR",
+            )
             ax.set_title(cell)
             ax.set_ylabel("rho", color="C0")
             ax2.set_ylabel("SNR", color="C3")
             ax.set_ylim(-1.2, 1.2)
-            ax2.set_yscale("log")
+            if np.any(np.array(means_snr) > 0):
+                ax2.set_yscale("log")
             ax.axhline(0, color="k", lw=0.5)
             ax.grid(alpha=0.3)
 
@@ -282,11 +290,18 @@ def main():
     ax[0].set_ylim(-1.2, 1.2)
     ax[0].grid(alpha=0.3)
 
-    ax[1].errorbar(dV_log2, means_snr, yerr=sems_snr, fmt="o-", color="C3")
+    ax[1].errorbar(
+        dV_log2,
+        np.maximum(np.array(means_snr), 1e-6),
+        yerr=sems_snr,
+        fmt="o-",
+        color="C3",
+    )
     ax[1].set_title("B-PN replication: SNR vs Delta_V")
     ax[1].set_xlabel("log2(Delta_V) [V]")
     ax[1].set_ylabel("SNR")
-    ax[1].set_yscale("log")
+    if np.any(np.array(means_snr) > 0):
+        ax[1].set_yscale("log")
     ax[1].grid(alpha=0.3)
     fig2.tight_layout()
     out2 = RESULTS / "figure_alexander_replication.pdf"

--- a/scripts/overnight/plot_theory_validation.py
+++ b/scripts/overnight/plot_theory_validation.py
@@ -1,0 +1,105 @@
+"""Plot Phase D theory validation outputs."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[2]
+DIR = REPO / "results" / "overnight-theory-validation"
+
+
+def plot_tau_e_equivalence():
+    fp = DIR / "tau_e_equivalence.npz"
+    if not fp.exists():
+        print("[plot] no tau_e_equivalence.npz")
+        return
+    z = np.load(fp, allow_pickle=True)
+    ts = z["ts"]
+    fig, axes = plt.subplots(1, 2, figsize=(11, 4))
+    cells = ["A-PS", "B-PS_tau6ms", "B-PS_tau30ms", "B-PS_tau100ms"]
+    colors = ["k", "C0", "C1", "C2"]
+    labels = ["A-PS (OUA, τ_e=0)", "B-PS τ_e=6ms (=τ_E)", "B-PS τ_e=30ms", "B-PS τ_e=100ms"]
+    for cell, color, label in zip(cells, colors, labels):
+        W = np.asarray(z[f"{cell}__W_learn"]).ravel()
+        axes[0].plot(ts, W, color=color, label=label)
+    axes[0].set_title("τ_e → 0 equivalence (Q9): W_learnable(t)")
+    axes[0].set_xlabel("time (s)")
+    axes[0].set_ylabel("W")
+    axes[0].legend(fontsize=8)
+    axes[0].grid(alpha=0.3)
+    axes[0].set_yscale("symlog", linthresh=1e-3)
+
+    # Eligibility comparison if available
+    for cell, color, label in zip(cells, colors, labels):
+        if f"{cell}__elig_learn" in z.files:
+            e = np.asarray(z[f"{cell}__elig_learn"]).ravel()
+            axes[1].plot(ts, e, color=color, label=label, alpha=0.7)
+    axes[1].set_title("Eligibility trace at learnable synapse")
+    axes[1].set_xlabel("time (s)")
+    axes[1].set_ylabel("e_ij")
+    axes[1].grid(alpha=0.3)
+    fig.tight_layout()
+    out = DIR / "figure_tau_e_equivalence.pdf"
+    fig.savefig(out, bbox_inches="tight")
+    plt.close(fig)
+    print(f"[plot] {out}")
+
+
+def plot_lyapunov():
+    fp = DIR / "lyapunov.npz"
+    if not fp.exists():
+        print("[plot] no lyapunov.npz")
+        return
+    z = np.load(fp, allow_pickle=True)
+    ts = z["ts"]
+    fig, ax = plt.subplots(1, 1, figsize=(6, 4))
+    for dV_pow in [-13, -11, -9]:
+        W = np.asarray(z[f"dV{dV_pow}__W_learn"]).ravel()
+        ax.plot(ts, W, label=f"ΔV = 2^{dV_pow}")
+    ax.set_title("Lyapunov check (Q5): A-PN W_learnable(t) under γ-clip")
+    ax.set_xlabel("time (s)")
+    ax.set_ylabel("W")
+    ax.legend()
+    ax.grid(alpha=0.3)
+    fig.tight_layout()
+    out = DIR / "figure_lyapunov.pdf"
+    fig.savefig(out, bbox_inches="tight")
+    plt.close(fig)
+    print(f"[plot] {out}")
+
+
+def plot_stein_bias():
+    import csv
+    fp = DIR / "stein_bias.csv"
+    if not fp.exists():
+        print("[plot] no stein_bias.csv")
+        return
+    rows = list(csv.DictReader(open(fp)))
+    fig, ax = plt.subplots(1, 1, figsize=(6, 4))
+    cells = sorted({r["file"].split("_dV")[0] for r in rows})
+    for cell in cells:
+        cells_rows = [r for r in rows if r["file"].startswith(cell)]
+        biases = [float(r["bias_proxy"]) for r in cells_rows]
+        ax.scatter([cell] * len(biases), biases, label=cell)
+    ax.axhline(0, color="k", lw=0.5)
+    ax.set_title("Stein-lemma bias: E[δ_r|V∈gate] − E[δ_r] at ΔV=2^-9")
+    ax.set_ylabel("bias proxy")
+    ax.grid(alpha=0.3)
+    fig.tight_layout()
+    out = DIR / "figure_stein_bias.pdf"
+    fig.savefig(out, bbox_inches="tight")
+    plt.close(fig)
+    print(f"[plot] {out}")
+
+
+if __name__ == "__main__":
+    plot_tau_e_equivalence()
+    plot_lyapunov()
+    plot_stein_bias()

--- a/scripts/overnight/run_learning_dynamics.py
+++ b/scripts/overnight/run_learning_dynamics.py
@@ -1,0 +1,212 @@
+"""Phase C — Learning dynamics with η > 0.
+
+Closed-loop η > 0 training on the Single Synapse Task using `LearningAgent`
+to carry a filtered scalar RPE state through the integrator. Tracks the
+learnable weight W_learnable(t) plus the RPE trace, the eligibility (for
+B cells), and the noisy/noiseless spike statistics.
+
+We use 3 ΔV points and 5 seeds per cell, T = 30 s (sufficient to see W
+trajectory diverge from initial value 0).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import diffrax as dfx  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import jax.random as jr  # noqa: E402
+import numpy as np  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from adaptive_SNN.models.networks.gated_LIF import GatedLIFNetwork  # noqa: E402
+from adaptive_SNN.models.networks.learning_agent import LearningAgent  # noqa: E402
+from adaptive_SNN.models.networks.noisy_network import NoisyNetwork  # noqa: E402
+from adaptive_SNN.models.networks.oua_LIF import OUAMeanReversionLIFNetwork  # noqa: E402
+from adaptive_SNN.models.networks.oua_eligibility_LIF import (  # noqa: E402
+    PerSynapseGatedEligibilityLIFNetwork,
+)
+from adaptive_SNN.models.networks.per_synapse_noisy_network import (  # noqa: E402
+    PerSynapseNoisyNetwork,
+)
+from adaptive_SNN.models.noise.oup import NeuralNoiseOUP  # noqa: E402
+from adaptive_SNN.models.noise.per_synapse_oup import PerSynapseOUP  # noqa: E402
+from adaptive_SNN.solver import simulate_noisy_SNN  # noqa: E402
+
+MASTER_SEED = 42
+N_NEURONS = 2
+N_INPUTS = 3
+INPUT_RATES = jnp.array([5000.0, 1250.0, 10.0])
+INPUT_TYPES = jnp.array([True, False, True])
+NOISE_SCALE_HYPERPARAM = 2.0
+BALANCE_TARGET = 0.0
+T_TOTAL = 30.0
+DT = 1e-4
+N_SAVE = 600
+TAU_RPE = 0.1
+RPE_NOISE_RATE = 1.0
+RPE_NOISE_STD = 1.0
+
+DELTA_V_SWEEP = jnp.array([2.0 ** -11, 2.0 ** -9, 2.0 ** -7])
+SEEDS = [42, 43, 44, 45, 46]
+CELL_IDS = ["A-PN", "A-PS", "A0-PN", "A0-PS", "B-PN", "B-PS"]
+
+LEARNING_RATES = {
+    "A-PN": 50.0,  "A0-PN": 50.0,
+    "A-PS": 50.0,  "A0-PS": 50.0,
+    "B-PN": 500.0, "B-PS": 500.0,
+}
+
+RESULTS_DIR = REPO_ROOT / "results" / "overnight-learning-dynamics"
+RAW_DIR = RESULTS_DIR / "raw"
+
+
+def make_initial_weights():
+    return jnp.tile(jnp.array([jnp.nan, jnp.nan, 1.1, 11.0, 0.0]), (N_NEURONS, 1))
+
+
+def _input_spike_fn(spike_key):
+    rates = INPUT_RATES
+
+    def fn(t, x, args):
+        step_idx = jnp.asarray(jnp.rint(t / DT), dtype=jnp.int64)
+        spikes_1d = jr.poisson(jr.fold_in(spike_key, step_idx), rates * DT, shape=(1, N_INPUTS))
+        return jnp.tile(spikes_1d, (N_NEURONS, 1)).astype(jnp.float64)
+
+    return fn
+
+
+def _make_base_network(model_cls, delta_V, key, use_gating=True):
+    kwargs = dict(dt=DT, N_neurons=N_NEURONS, N_inputs=N_INPUTS,
+                  initial_weight_matrix=make_initial_weights(),
+                  input_types=INPUT_TYPES, fully_connected_input=True, key=key)
+    if model_cls is GatedLIFNetwork:
+        net = model_cls(**kwargs)
+        object.__setattr__(net, "delta_V", float(delta_V))
+        return net
+    if model_cls is OUAMeanReversionLIFNetwork:
+        return model_cls(**kwargs, delta_V=float(delta_V), use_gating=use_gating, update_clip=1.0)
+    if model_cls is PerSynapseGatedEligibilityLIFNetwork:
+        return model_cls(**kwargs, delta_V=float(delta_V))
+    raise ValueError(model_cls)
+
+
+def _make_noisy(cell_id, delta_V, sigma_pn, sigma_ps, key):
+    net_key, _ = jr.split(key)
+    if cell_id in ("A-PN", "A0-PN"):
+        use_gating = (cell_id == "A-PN")
+        net = _make_base_network(OUAMeanReversionLIFNetwork, delta_V, net_key, use_gating=use_gating)
+        return NoisyNetwork(net, NeuralNoiseOUP(tau=net.tau_E, dim=N_NEURONS, noise_std=sigma_pn), min_noise_std=5e-9)
+    if cell_id in ("A-PS", "A0-PS"):
+        use_gating = (cell_id == "A-PS")
+        net = _make_base_network(OUAMeanReversionLIFNetwork, delta_V, net_key, use_gating=use_gating)
+        oup = PerSynapseOUP(N_neurons=N_NEURONS, N_inputs=N_INPUTS, excitatory_mask=net.excitatory_mask, tau=net.tau_E, noise_std=sigma_ps)
+        return PerSynapseNoisyNetwork(net, oup, min_noise_std=5e-9)
+    if cell_id == "B-PN":
+        net = _make_base_network(GatedLIFNetwork, delta_V, net_key)
+        return NoisyNetwork(net, NeuralNoiseOUP(tau=net.tau_E, dim=N_NEURONS, noise_std=sigma_pn), min_noise_std=5e-9)
+    if cell_id == "B-PS":
+        net = _make_base_network(PerSynapseGatedEligibilityLIFNetwork, delta_V, net_key)
+        oup = PerSynapseOUP(N_neurons=N_NEURONS, N_inputs=N_INPUTS, excitatory_mask=net.excitatory_mask, tau=net.tau_E, noise_std=sigma_ps)
+        return PerSynapseNoisyNetwork(net, oup, min_noise_std=5e-9)
+    raise ValueError(cell_id)
+
+
+def _save_fn(cell_id):
+    def fn(t, y, args):
+        inner = y.network_state.network_state
+        common = {
+            "V": inner.V,
+            "S": inner.S,
+            "G_learn": jnp.atleast_1d(inner.G[0, 4]),
+            "W_learn": jnp.atleast_1d(inner.W[0, 4]),
+            "rpe": jnp.atleast_1d(y.rpe),
+        }
+        if cell_id.startswith("B-"):
+            common["elig_learn"] = jnp.atleast_1d(inner.features.eligibility[0, 4])
+        return common
+    return fn
+
+
+def _build_args(spike_key, rpe_noise_key, sigma_ps, lr):
+    return {
+        "get_input_spikes": _input_spike_fn(spike_key),
+        "get_learning_rate": lambda t, x, a: jnp.array(lr),
+        "get_desired_balance": lambda t, x, a: jnp.array(BALANCE_TARGET),
+        "noise_scale_hyperparam": NOISE_SCALE_HYPERPARAM,
+        "use_noise": jnp.array([True, False]),
+        "per_synapse_noise_std_target": sigma_ps,
+        "rpe_noise_key": rpe_noise_key,
+    }
+
+
+def run_cell(cell_id, delta_V, seed, sigma_pn, sigma_ps, T=T_TOTAL, lr=None):
+    base_key = jr.PRNGKey(seed)
+    cell_key, spike_key, brown_key, rpe_key = jr.split(base_key, 4)
+    noisy = _make_noisy(cell_id, delta_V, sigma_pn, sigma_ps, cell_key)
+    agent = LearningAgent(noisy, tau_RPE=TAU_RPE, rpe_noise_rate=RPE_NOISE_RATE, rpe_noise_std=RPE_NOISE_STD)
+    args = _build_args(spike_key, rpe_key, sigma_ps, lr if lr is not None else LEARNING_RATES.get(cell_id, 1.0))
+    save_ts = jnp.linspace(0.0, T, N_SAVE)
+    saveat = dfx.SaveAt(subs=dfx.SubSaveAt(ts=save_ts, fn=_save_fn(cell_id)))
+    return simulate_noisy_SNN(agent, dfx.EulerHeun(), 0.0, T, DT, agent.initial, save_at=saveat, args=args, key=brown_key)
+
+
+def main():
+    from run_paired_comparison_v2 import calibrate
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    RAW_DIR.mkdir(parents=True, exist_ok=True)
+    print("=" * 78)
+    print("Phase C — η>0 learning dynamics (closed-loop via LearningAgent)")
+    print(f"T={T_TOTAL}s, dt={DT}s, cells={CELL_IDS}")
+    print("=" * 78)
+
+    calib = calibrate()
+    sigma_pn = calib["sigma_per_neuron"]
+    sigma_ps = calib["sigma_per_synapse"]
+    with open(RESULTS_DIR / "calibration.json", "w") as fh:
+        json.dump(calib, fh, indent=2)
+    print(f"[calib] sigma_pn={sigma_pn:.2e}, sigma_ps={sigma_ps:.3f}")
+
+    n_total = len(CELL_IDS) * len(DELTA_V_SWEEP) * len(SEEDS)
+    elapsed = 0.0
+    done = 0
+    for cell_id in CELL_IDS:
+        for dV in DELTA_V_SWEEP:
+            dV_pow = int(round(np.log2(float(dV))))
+            for seed in SEEDS:
+                tag = f"{cell_id}_dV2^{dV_pow}_seed{seed}"
+                path = RAW_DIR / f"{tag}.npz"
+                if path.exists():
+                    done += 1
+                    continue
+                t0 = time.time()
+                try:
+                    sol = run_cell(cell_id, float(dV), seed, sigma_pn, sigma_ps, T=T_TOTAL)
+                except Exception as exc:
+                    print(f"[ERR] {tag}: {type(exc).__name__}: {str(exc)[:150]}")
+                    continue
+                wall = time.time() - t0
+                elapsed += wall
+                done += 1
+                ts = np.asarray(sol.ts)
+                ys = {k: np.asarray(v) for k, v in sol.ys.items()}
+                np.savez(path, ts=ts, **ys, cell_id=cell_id, delta_V=float(dV), seed=seed,
+                         sigma_pn=sigma_pn, sigma_ps=sigma_ps,
+                         lr=LEARNING_RATES.get(cell_id, 1.0))
+                W_final = float(ys["W_learn"][-1])
+                fr_n = float(ys["S"][:, 0].sum() / T_TOTAL)
+                print(f"[done {done}/{n_total}] {tag} wall={wall:.1f}s W_final={W_final:.3e} fr_n={fr_n:.2f}Hz")
+    print(f"[total] {elapsed:.1f}s new")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/overnight/run_learning_dynamics.py
+++ b/scripts/overnight/run_learning_dynamics.py
@@ -40,7 +40,7 @@ from adaptive_SNN.models.networks.per_synapse_noisy_network import (  # noqa: E4
 )
 from adaptive_SNN.models.noise.oup import NeuralNoiseOUP  # noqa: E402
 from adaptive_SNN.models.noise.per_synapse_oup import PerSynapseOUP  # noqa: E402
-from adaptive_SNN.solver import simulate_noisy_SNN  # noqa: E402
+from adaptive_SNN.solver import solve_ODE  # noqa: E402
 
 MASTER_SEED = 42
 N_NEURONS = 2
@@ -157,7 +157,7 @@ def run_cell(cell_id, delta_V, seed, sigma_pn, sigma_ps, T=T_TOTAL, lr=None):
     args = _build_args(spike_key, rpe_key, sigma_ps, lr if lr is not None else LEARNING_RATES.get(cell_id, 1.0))
     save_ts = jnp.linspace(0.0, T, N_SAVE)
     saveat = dfx.SaveAt(subs=dfx.SubSaveAt(ts=save_ts, fn=_save_fn(cell_id)))
-    return simulate_noisy_SNN(agent, dfx.EulerHeun(), 0.0, T, DT, agent.initial, save_at=saveat, args=args, key=brown_key)
+    return solve_ODE(agent, dfx.EulerHeun(), 0.0, T, DT, agent.initial, save_at=saveat, args=args, key=brown_key)
 
 
 def main():

--- a/scripts/overnight/run_paired_comparison.py
+++ b/scripts/overnight/run_paired_comparison.py
@@ -59,7 +59,7 @@ from adaptive_SNN.models.networks.per_synapse_noisy_network import (  # noqa: E4
 )
 from adaptive_SNN.models.noise.oup import NeuralNoiseOUP  # noqa: E402
 from adaptive_SNN.models.noise.per_synapse_oup import PerSynapseOUP  # noqa: E402
-from adaptive_SNN.solver import simulate_noisy_SNN  # noqa: E402
+from adaptive_SNN.solver import solve_ODE  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -286,7 +286,7 @@ def run_cell(cell_id, delta_V, seed, sigma_per_neuron, sigma_per_synapse, T=T_TO
     save_fn = _make_save_fn(cell_id)
     saveat = dfx.SaveAt(subs=dfx.SubSaveAt(ts=save_ts, fn=save_fn))
 
-    sol = simulate_noisy_SNN(
+    sol = solve_ODE(
         wrap, dfx.EulerHeun(), 0.0, T, DT, initial,
         save_at=saveat, args=args, key=brown_key,
     )
@@ -337,7 +337,7 @@ def calibrate(noise_scale_hyperparam=1.0, min_noise_std=1e-9, T_warm=20.0, seed=
         }
 
     saveat = dfx.SaveAt(subs=dfx.SubSaveAt(ts=save_ts, fn=save_fn))
-    sol = simulate_noisy_SNN(
+    sol = solve_ODE(
         wrap, dfx.EulerHeun(), 0.0, T_warm, DT, wrap.initial,
         save_at=saveat, args=args, key=brown_key,
     )

--- a/scripts/overnight/run_paired_comparison.py
+++ b/scripts/overnight/run_paired_comparison.py
@@ -1,0 +1,505 @@
+"""Paired 4-cell Single Synapse Task comparison (P3 of overnight execution plan).
+
+Cells (unified §4.3):
+- A-PN: per-neuron OUA, gate-on. OUAMeanReversionLIFNetwork + BroadcastingNoisyNetwork
+- A-PS: per-synapse OUA, gate-on. OUAMeanReversionLIFNetwork + PerSynapseNoisyNetwork
+- B-PN: per-neuron Eligibility, gate-on. GatedLIFNetwork + NoisyNetwork (Alexander's cell)
+- B-PS: per-synapse Eligibility, gate-on. PerSynapseGatedEligibilityLIFNetwork + PerSynapseNoisyNetwork
+
+Pairs (per the plan):
+- Pair A: (A-PN, A-PS) share seed
+- Pair B: (B-PN, B-PS) share seed
+
+For each cell × ΔV × seed:
+- Single Synapse Task (1 noisy neuron + 1 noiseless twin, shared input)
+- eta = 0 (gradient analysis only; weights do not actually change)
+- Extract per-step gradient signal for the learnable synapse onto the noisy neuron
+- Aggregate to ρ (alignment with true sign) and SNR
+- Track γ-clip engagement fraction, balance (constant here as no rebalancing),
+  mean voltage, firing rate
+
+Outputs:
+- results/overnight-single-synapse/calibration.json
+- results/overnight-single-synapse/raw/{cell_id}_{dV_pow}_seed{seed}.npz
+- results/overnight-single-synapse/summary.csv
+- results/overnight-single-synapse/paired_summary.csv
+- figure_paired_comparison.pdf, figure_alexander_replication.pdf
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import diffrax as dfx
+import equinox as eqx
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from adaptive_SNN.models.networks.base import LIFState  # noqa: E402
+from adaptive_SNN.models.networks.gated_LIF import GatedLIFNetwork  # noqa: E402
+from adaptive_SNN.models.networks.noisy_network import NoisyNetwork, NoisyNetworkState  # noqa: E402
+from adaptive_SNN.models.networks.oua_LIF import OUAMeanReversionLIFNetwork  # noqa: E402
+from adaptive_SNN.models.networks.oua_eligibility_LIF import (  # noqa: E402
+    PerSynapseGatedEligibilityLIFNetwork,
+)
+from adaptive_SNN.models.networks.per_synapse_noisy_network import (  # noqa: E402
+    BroadcastingNoisyNetwork,
+    PerSynapseNoisyNetwork,
+)
+from adaptive_SNN.models.noise.oup import NeuralNoiseOUP  # noqa: E402
+from adaptive_SNN.models.noise.per_synapse_oup import PerSynapseOUP  # noqa: E402
+from adaptive_SNN.solver import simulate_noisy_SNN  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Task constants — Single Synapse Task (Alexander §2.6.1, May-18 thesis)
+# ---------------------------------------------------------------------------
+MASTER_SEED = 42
+N_NEURONS = 2  # noisy (index 0) + noiseless twin (index 1)
+N_INPUTS = 3   # E 5 kHz, I 1.25 kHz, E learnable 10 Hz
+INPUT_RATES = jnp.array([5000.0, 1250.0, 10.0])
+INPUT_TYPES = jnp.array([True, False, True])  # E, I, E
+# Initial weights (Alexander's defaults): no recurrent (NaN), input weights as below
+def make_initial_weights():
+    w = jnp.tile(
+        jnp.array([jnp.nan, jnp.nan, 1.1, 11.0, 0.0]), (N_NEURONS, 1)
+    )
+    return w
+
+
+# Time parameters
+T_TOTAL = 20.0   # 20s per simulation (reduced from Alexander's 100s for overnight budget)
+DT = 1e-4
+WARMUP_T = 5.0   # discard first 5s for steady-state estimation
+N_SAVE = 500     # save points (sparse)
+TAU_RPE = 0.1
+
+# Sweep
+DELTA_V_SWEEP = jnp.array([2.0 ** -k for k in range(7, 14)])  # 2^-7 ... 2^-13 (in V)
+SEEDS = [42, 43, 44, 45, 46]
+
+CELL_IDS = ["A-PN", "A-PS", "B-PN", "B-PS"]
+RESULTS_DIR = REPO_ROOT / "results" / "overnight-single-synapse"
+RAW_DIR = RESULTS_DIR / "raw"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _input_spike_fn_factory(spike_key):
+    """Stable Poisson spikes shared across both neurons (tiled)."""
+    rates = INPUT_RATES
+
+    def fn(t, x, args):
+        step_idx = jnp.asarray(jnp.rint(t / DT), dtype=jnp.int64)
+        spikes_1d = jr.poisson(
+            jr.fold_in(spike_key, step_idx), rates * DT, shape=(1, N_INPUTS)
+        )
+        return jnp.tile(spikes_1d, (N_NEURONS, 1)).astype(jnp.float64)
+
+    return fn
+
+
+# ---------------------------------------------------------------------------
+# Cell factories
+# ---------------------------------------------------------------------------
+def _make_base_network(model_cls, delta_V, key):
+    """Build the underlying LIF network with the standard SST geometry."""
+    kwargs = dict(
+        dt=DT,
+        N_neurons=N_NEURONS,
+        N_inputs=N_INPUTS,
+        initial_weight_matrix=make_initial_weights(),
+        input_types=INPUT_TYPES,
+        fully_connected_input=True,
+        key=key,
+    )
+    if model_cls is GatedLIFNetwork:
+        net = model_cls(**kwargs)
+        # Set delta_V via attr (GatedLIFNetwork doesn't accept it in __init__)
+        object.__setattr__(net, "delta_V", float(delta_V))
+        return net
+    if model_cls is OUAMeanReversionLIFNetwork:
+        return model_cls(
+            **kwargs, delta_V=float(delta_V), use_gating=True, update_clip=1.0
+        )
+    if model_cls is PerSynapseGatedEligibilityLIFNetwork:
+        return model_cls(**kwargs, delta_V=float(delta_V))
+    raise ValueError(f"Unknown model_cls {model_cls}")
+
+
+def _make_cell(cell_id, delta_V, sigma_per_neuron, sigma_per_synapse, key):
+    """Return the noisy-wrapped model for one cell."""
+    net_key, _ = jr.split(key)
+    if cell_id == "A-PN":
+        # per-neuron OUA: OUAMeanReversionLIFNetwork + NoisyNetwork. OUA's
+        # compute_weight_updates falls back to the per-neuron path (reading
+        # excitatory_noise + noise_std) when per_synapse_excitatory_noise is
+        # absent. This is the alpha = 0 endpoint of unified Eq. 2.4 routed
+        # through the existing Alexander per-neuron noise machinery (no
+        # broadcasting hack needed).
+        net = _make_base_network(OUAMeanReversionLIFNetwork, delta_V, net_key)
+        noise = NeuralNoiseOUP(tau=net.tau_E, dim=N_NEURONS, noise_std=sigma_per_neuron)
+        wrap = NoisyNetwork(net, noise, min_noise_std=0.0)
+        return wrap, "per_neuron"
+    if cell_id == "A-PS":
+        net = _make_base_network(OUAMeanReversionLIFNetwork, delta_V, net_key)
+        noise = PerSynapseOUP(
+            N_neurons=N_NEURONS,
+            N_inputs=N_INPUTS,
+            excitatory_mask=net.excitatory_mask,
+            tau=net.tau_E,
+            noise_std=sigma_per_synapse,
+        )
+        wrap = PerSynapseNoisyNetwork(net, noise, min_noise_std=0.0)
+        return wrap, "per_synapse"
+    if cell_id == "B-PN":
+        net = _make_base_network(GatedLIFNetwork, delta_V, net_key)
+        noise = NeuralNoiseOUP(tau=net.tau_E, dim=N_NEURONS, noise_std=sigma_per_neuron)
+        wrap = NoisyNetwork(net, noise, min_noise_std=0.0)
+        return wrap, "per_neuron"
+    if cell_id == "B-PS":
+        net = _make_base_network(PerSynapseGatedEligibilityLIFNetwork, delta_V, net_key)
+        noise = PerSynapseOUP(
+            N_neurons=N_NEURONS,
+            N_inputs=N_INPUTS,
+            excitatory_mask=net.excitatory_mask,
+            tau=net.tau_E,
+            noise_std=sigma_per_synapse,
+        )
+        wrap = PerSynapseNoisyNetwork(net, noise, min_noise_std=0.0)
+        return wrap, "per_synapse"
+    raise ValueError(f"Unknown cell_id {cell_id}")
+
+
+# ---------------------------------------------------------------------------
+# Single-step gradient signal extractor (eta=0 analysis)
+# ---------------------------------------------------------------------------
+def _extract_dW_signal(cell_id, wrap, state, args, t):
+    """Compute the per-step learnable-synapse gradient signal at time t.
+
+    For OUA cells: dW from compute_weight_updates (which reads
+    per_synapse_excitatory_noise and synaptic activity G).
+    For eligibility cells: eligibility * RPE (the would-be weight update if
+    eta != 0). With eta = 0, weights don't change but the signal carries the
+    information.
+    """
+    if cell_id.startswith("A-"):
+        # OUA: dW = lr * RPE * relative_noise * s_ij * gate
+        # Use lr = 1 to make the signal independent of an arbitrary scaling.
+        inner = state.network_state
+        local_args = dict(args)
+        local_args["get_learning_rate"] = lambda t_, x, a: jnp.array(1.0)
+        dW = wrap.base_network.compute_weight_updates(t, inner, local_args)
+    else:
+        # Eligibility: signal = RPE * eligibility (the integrand of dw/dt with lr=1)
+        inner = state.network_state
+        RPE = local_args = args.get("RPE", jnp.array(0.0)) if isinstance(args, dict) else jnp.array(0.0)
+        elig = inner.features.eligibility
+        dW = RPE * elig
+        dW = jnp.where(jnp.isnan(inner.W), 0.0, dW)
+    return dW
+
+
+# ---------------------------------------------------------------------------
+# Simulation: run one cell × ΔV × seed, return saved trajectories
+# ---------------------------------------------------------------------------
+def _make_save_fn(cell_id):
+    """Save the minimal set of fields needed for downstream metrics."""
+
+    def fn(t, y, args):
+        inner = y.network_state
+        # All entries must be jnp arrays (the simulator's preallocator reads .shape).
+        common = {
+            "V": inner.V,
+            "S": inner.S,
+            "G_learnable": jnp.atleast_1d(inner.G[0, 4]),
+            "W_learnable": jnp.atleast_1d(inner.W[0, 4]),
+            "RPE": jnp.atleast_1d(args.get("RPE", jnp.array(0.0))).ravel(),
+            "noise_state": y.noise_state,
+        }
+        if cell_id.startswith("B-"):
+            common["eligibility_learnable"] = jnp.atleast_1d(
+                inner.features.eligibility[0, 4]
+            )
+        return common
+
+    return fn
+
+
+def _build_initial_args(wrap, cell_id, spike_key, sigma_pn, sigma_ps):
+    """Args dict for one simulation."""
+    args = {
+        "get_input_spikes": _input_spike_fn_factory(spike_key),
+        "get_learning_rate": lambda t, x, a: jnp.array(0.0),  # eta = 0 (gradient analysis only)
+        "get_desired_balance": lambda t, x, a: jnp.array(0.0),
+        # Activity-dependent calibration ON for per-neuron cells (matches Alexander's
+        # noise_level=1.0 default in single_synapse_learning). For per-synapse cells we
+        # override via per_synapse_noise_std_target (frozen scalar from calibration).
+        "noise_scale_hyperparam": 1.0,
+        "use_noise": jnp.array([True, False]),  # neuron 0 noisy, neuron 1 noiseless
+        "RPE": jnp.array(0.0),  # eta=0 so RPE is unused for plasticity here
+        "per_synapse_noise_std_target": sigma_ps,
+    }
+    return args
+
+
+def _build_RPE_decay_step(tau_RPE, dt):
+    """Discrete OU-like decay step for RPE: dRPE/dt = -RPE/tau + drive."""
+    alpha = jnp.exp(-dt / tau_RPE)
+
+    def step_RPE(RPE_prev, drive):
+        return RPE_prev * alpha + drive * (1 - alpha)
+
+    return step_RPE
+
+
+def run_cell(cell_id, delta_V, seed, sigma_per_neuron, sigma_per_synapse, T=T_TOTAL):
+    """Run a single (cell, delta_V, seed) simulation. Returns metrics dict."""
+    base_key = jr.PRNGKey(seed)
+    cell_key, spike_key, brown_key = jr.split(base_key, 3)
+    wrap, geometry = _make_cell(
+        cell_id, delta_V, sigma_per_neuron, sigma_per_synapse, cell_key
+    )
+
+    args = _build_initial_args(wrap, cell_id, spike_key, sigma_per_neuron, sigma_per_synapse)
+
+    # We need to evolve the RPE ourselves since the model machinery for it lives
+    # in the Agent/Env stack we are not using here. We'll instead run the SDE
+    # without RPE-state-coupling: at each save point compute the instantaneous
+    # spike-difference RPE from saved spikes. eta=0 means RPE doesn't feed back
+    # into the network anyway.
+
+    initial = wrap.initial
+    save_ts = jnp.linspace(0.0, T, N_SAVE)
+    save_fn = _make_save_fn(cell_id)
+    saveat = dfx.SaveAt(subs=dfx.SubSaveAt(ts=save_ts, fn=save_fn))
+
+    sol = simulate_noisy_SNN(
+        wrap, dfx.EulerHeun(), 0.0, T, DT, initial,
+        save_at=saveat, args=args, key=brown_key,
+    )
+    return sol
+
+
+# ---------------------------------------------------------------------------
+# Calibration: 60s warmup with GatedLIFNetwork to measure <s_ij^2>_ss
+# ---------------------------------------------------------------------------
+def calibrate(noise_scale_hyperparam=1.0, min_noise_std=1e-9, T_warm=20.0, seed=MASTER_SEED):
+    """Measure steady-state <s_ij^2> and |E_i| for the SST setup.
+
+    Returns dict with sigma_per_neuron, sigma_per_synapse, |E_i|, <s^2>.
+    """
+    key = jr.PRNGKey(seed)
+    net_key, spike_key, brown_key = jr.split(key, 3)
+    net = GatedLIFNetwork(
+        N_neurons=N_NEURONS,
+        N_inputs=N_INPUTS,
+        dt=DT,
+        initial_weight_matrix=make_initial_weights(),
+        input_types=INPUT_TYPES,
+        fully_connected_input=True,
+        key=net_key,
+    )
+    object.__setattr__(net, "delta_V", 1e-3)
+    noise = NeuralNoiseOUP(tau=net.tau_E, dim=N_NEURONS, noise_std=min_noise_std)
+    wrap = NoisyNetwork(net, noise, min_noise_std=min_noise_std)
+
+    args = {
+        "get_input_spikes": _input_spike_fn_factory(spike_key),
+        "get_learning_rate": lambda t, x, a: jnp.array(0.0),
+        "get_desired_balance": lambda t, x, a: jnp.array(0.0),
+        "noise_scale_hyperparam": noise_scale_hyperparam,
+        "use_noise": jnp.array([True, False]),
+        "RPE": jnp.array(0.0),
+    }
+
+    save_ts = jnp.linspace(5.0, T_warm, 200)
+
+    def save_fn(t, y, args):
+        return {
+            "V0": jnp.atleast_1d(y.network_state.V[0]),
+            "G_E": y.network_state.G[0, 2:],
+            "var_E": jnp.atleast_1d(y.network_state.var_E_conductance[0]),
+            "mean_E": jnp.atleast_1d(y.network_state.mean_E_conductance[0]),
+            "noise_state_0": jnp.atleast_1d(y.noise_state[0]),
+        }
+
+    saveat = dfx.SaveAt(subs=dfx.SubSaveAt(ts=save_ts, fn=save_fn))
+    sol = simulate_noisy_SNN(
+        wrap, dfx.EulerHeun(), 0.0, T_warm, DT, wrap.initial,
+        save_at=saveat, args=args, key=brown_key,
+    )
+
+    # <s_ij^2>_ss over excitatory input synapses
+    # Input idx 0 = E (5 kHz), 1 = I (1.25 kHz), 2 = E (10 Hz learnable).
+    G_E = sol.ys["G_E"]  # shape (T, N_inputs)
+    G_exc = G_E[:, [0, 2]] / net.synaptic_increment  # convert G (nS) -> s (dimensionless)
+    s2_mean = float(jnp.mean(G_exc ** 2))
+    var_E_ss = float(jnp.mean(sol.ys["var_E"][-50:]))  # nS^2
+    sigma_per_neuron = float(jnp.sqrt(var_E_ss) * noise_scale_hyperparam + min_noise_std)  # nS
+    abs_E_i = 2.0  # 2 existing excitatory input synapses onto neuron 0 in SST
+
+    # Eq. 2.6 of unified model (post-substitution tau_E = tau_xi):
+    #   sigma_zeta^2 [unified nS] = sigma_xi^2 / (|E_i| * <s^2>)
+    # Conversion to repo dimensionless W units: divide by w0 = synaptic_increment.
+    sigma_per_synapse = float(
+        sigma_per_neuron / (net.synaptic_increment * jnp.sqrt(abs_E_i * s2_mean))
+    )
+    return {
+        "sigma_per_neuron": sigma_per_neuron,
+        "sigma_per_synapse": sigma_per_synapse,
+        "abs_E_i": abs_E_i,
+        "s2_mean": s2_mean,
+        "var_E_ss": var_E_ss,
+        "noise_scale_hyperparam": noise_scale_hyperparam,
+        "min_noise_std": min_noise_std,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    RAW_DIR.mkdir(parents=True, exist_ok=True)
+
+    print("=" * 78)
+    print("OUA overnight P3 — paired 4-cell Single Synapse Task comparison")
+    print(f"Master seed = {MASTER_SEED}, T = {T_TOTAL}s, dt = {DT}s")
+    print(f"DeltaV sweep: {[float(x) for x in DELTA_V_SWEEP]}")
+    print(f"Seeds: {SEEDS}")
+    print("=" * 78)
+
+    # ---- Calibration ----
+    print("[calibration] measuring <s^2>_ss for variance match")
+    t0 = time.time()
+    calib = calibrate()
+    print(f"[calibration] done in {time.time() - t0:.1f}s")
+    print(f"[calibration] sigma_per_neuron = {calib['sigma_per_neuron']:.3e} nS")
+    print(f"[calibration] sigma_per_synapse = {calib['sigma_per_synapse']:.3e} nS")
+    print(f"[calibration] <s^2>_ss = {calib['s2_mean']:.3e}, |E_i| = {calib['abs_E_i']}")
+    with open(RESULTS_DIR / "calibration.json", "w") as fh:
+        json.dump(calib, fh, indent=2)
+
+    sigma_pn = calib["sigma_per_neuron"]
+    sigma_ps = calib["sigma_per_synapse"]
+
+    # ---- Run all (cell, dV, seed) combinations ----
+    n_total = len(CELL_IDS) * len(DELTA_V_SWEEP) * len(SEEDS)
+    print(f"[runs] {n_total} simulations total")
+    summary_rows = []
+    elapsed_total = 0.0
+
+    for cell_id in CELL_IDS:
+        for k, delta_V in enumerate(DELTA_V_SWEEP):
+            dV_pow = -7 - k  # 2^-7, 2^-8, ..., 2^-13
+            for seed in SEEDS:
+                tag = f"{cell_id}_dV2^{dV_pow}_seed{seed}"
+                save_path = RAW_DIR / f"{tag}.npz"
+                if save_path.exists():
+                    print(f"[skip] {tag} already done")
+                    continue
+                t0 = time.time()
+                try:
+                    sol = run_cell(
+                        cell_id,
+                        float(delta_V),
+                        seed,
+                        sigma_pn,
+                        sigma_ps,
+                        T=T_TOTAL,
+                    )
+                except Exception as exc:
+                    print(f"[ERROR] {tag}: {exc}")
+                    continue
+                wall = time.time() - t0
+                elapsed_total += wall
+
+                # Save raw
+                ts = np.asarray(sol.ts)
+                V = np.asarray(sol.ys["V"])
+                S = np.asarray(sol.ys["S"])
+                G_learn = np.asarray(sol.ys["G_learnable"])
+                W_learn = np.asarray(sol.ys["W_learnable"])
+                RPE_arr = np.asarray(sol.ys["RPE"])
+                noise = np.asarray(sol.ys["noise_state"])
+                extras = {}
+                if "eligibility_learnable" in sol.ys:
+                    extras["eligibility_learnable"] = np.asarray(
+                        sol.ys["eligibility_learnable"]
+                    )
+                np.savez(
+                    save_path,
+                    ts=ts,
+                    V=V,
+                    S=S,
+                    G_learn=G_learn,
+                    W_learn=W_learn,
+                    RPE=RPE_arr,
+                    noise=noise,
+                    cell_id=cell_id,
+                    delta_V=float(delta_V),
+                    seed=seed,
+                    sigma_pn=sigma_pn,
+                    sigma_ps=sigma_ps,
+                    master_seed=MASTER_SEED,
+                    **extras,
+                )
+
+                # Quick metrics: compute spike-diff RPE proxy and use it for SNR
+                # The saved spikes are binary {0, 1}; RPE proxy = S0 - S1.
+                rpe_proxy = S[:, 0] - S[:, 1]
+                # Steady-state window
+                ss_mask = ts > WARMUP_T
+                # Gradient signal proxy (cell-dependent):
+                #   OUA: dW = RPE_proxy * (noise_to_learnable) * (G_learn / w0) * gate (uncomputable
+                #     without gate value here, so we just save the raw fields and compute later)
+                # For overnight, the cleaner approach is just to log: |RPE| activity,
+                # firing rate, mean V, balance proxy (none here).
+                fr_noisy = float(np.mean(S[ss_mask, 0]) / DT * (ts[-1] - ts[0]) / N_SAVE)
+                fr_clean = float(np.mean(S[ss_mask, 1]) / DT * (ts[-1] - ts[0]) / N_SAVE)
+                v_mean_noisy = float(np.mean(V[ss_mask, 0]))
+                rpe_var = float(np.var(rpe_proxy[ss_mask]))
+
+                summary_rows.append(
+                    {
+                        "cell_id": cell_id,
+                        "delta_V": float(delta_V),
+                        "dV_pow": dV_pow,
+                        "seed": seed,
+                        "fr_noisy": fr_noisy,
+                        "fr_clean": fr_clean,
+                        "v_mean_noisy": v_mean_noisy,
+                        "rpe_var": rpe_var,
+                        "wall_s": wall,
+                    }
+                )
+                print(
+                    f"[done] {tag} wall={wall:.1f}s fr={fr_noisy:.1f}Hz vmean={v_mean_noisy*1000:.1f}mV"
+                )
+
+    # ---- Save summary ----
+    if summary_rows:
+        import csv
+        with open(RESULTS_DIR / "summary.csv", "w", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=list(summary_rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(summary_rows)
+        print(f"[summary] wrote {len(summary_rows)} rows to summary.csv")
+        print(f"[total] {elapsed_total:.1f}s wall on {len(summary_rows)} simulations")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/overnight/run_paired_comparison_v2.py
+++ b/scripts/overnight/run_paired_comparison_v2.py
@@ -1,0 +1,307 @@
+"""Paired comparison v2 — Single Synapse Task with Alexander Eq. 33/34 metrics.
+
+Improvements over v1:
+- 6 cells (adds gate-off OUA control pair A0-PN, A0-PS).
+- noise_scale_hyperparam = 2.0 (drives firing rate closer to Alexander Table 1 target).
+- balance = 1.0 (heterosynaptic rebalancing enabled per Alexander §2.5 / Eq. 32).
+- Saves the noiseless-twin spike train and full V[:, 0] trajectory for offline
+  ρ / SNR computation per Alexander Eq. 33 / 34.
+- Saves enough state to recompute the OUA eligibility-equivalent
+  e_ij(t) = ζ_ij(t) · s_ij(t) · γ(V_i(t)) offline.
+
+Cells:
+  A-PN  : OUAMeanReversionLIFNetwork + NoisyNetwork (per-neuron OU)        gate ON
+  A-PS  : OUAMeanReversionLIFNetwork + PerSynapseNoisyNetwork              gate ON
+  A0-PN : OUAMeanReversionLIFNetwork + NoisyNetwork                        gate OFF (control)
+  A0-PS : OUAMeanReversionLIFNetwork + PerSynapseNoisyNetwork              gate OFF (control)
+  B-PN  : GatedLIFNetwork + NoisyNetwork                                   gate ON (Alexander's cell)
+  B-PS  : PerSynapseGatedEligibilityLIFNetwork + PerSynapseNoisyNetwork    gate ON (co-headline)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import diffrax as dfx  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import jax.random as jr  # noqa: E402
+import numpy as np  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from adaptive_SNN.models.networks.gated_LIF import GatedLIFNetwork  # noqa: E402
+from adaptive_SNN.models.networks.noisy_network import NoisyNetwork  # noqa: E402
+from adaptive_SNN.models.networks.oua_LIF import OUAMeanReversionLIFNetwork  # noqa: E402
+from adaptive_SNN.models.networks.oua_eligibility_LIF import (  # noqa: E402
+    PerSynapseGatedEligibilityLIFNetwork,
+)
+from adaptive_SNN.models.networks.per_synapse_noisy_network import (  # noqa: E402
+    PerSynapseNoisyNetwork,
+)
+from adaptive_SNN.models.noise.oup import NeuralNoiseOUP  # noqa: E402
+from adaptive_SNN.models.noise.per_synapse_oup import PerSynapseOUP  # noqa: E402
+from adaptive_SNN.solver import simulate_noisy_SNN  # noqa: E402
+
+# ---------------------------------------------------------------------------
+MASTER_SEED = 42
+N_NEURONS = 2
+N_INPUTS = 3
+INPUT_RATES = jnp.array([5000.0, 1250.0, 10.0])
+INPUT_TYPES = jnp.array([True, False, True])  # E, I, E
+NOISE_SCALE_HYPERPARAM = 2.0  # bumped from Alexander's default 0.0; with min=5nS gives σ≈13nS
+BALANCE_TARGET = 0.0          # match Alexander's SST config (initial weights pre-tuned)
+TAU_RPE = 0.1
+T_TOTAL = 60.0                # 60s window (Alexander uses 300s; we trade off budget)
+DT = 1e-4
+WARMUP_T = 10.0
+N_SAVE = 2400                 # save every 25ms for fine-enough resolution
+
+DELTA_V_SWEEP = jnp.array([2.0 ** -k for k in range(7, 14)])  # 2^-7..2^-13
+SEEDS = [42, 43, 44, 45, 46]
+CELL_IDS = ["A-PN", "A-PS", "A0-PN", "A0-PS", "B-PN", "B-PS"]
+RESULTS_DIR = REPO_ROOT / "results" / "overnight-single-synapse-v2"
+RAW_DIR = RESULTS_DIR / "raw"
+
+
+def make_initial_weights():
+    return jnp.tile(jnp.array([jnp.nan, jnp.nan, 1.1, 11.0, 0.0]), (N_NEURONS, 1))
+
+
+def _input_spike_fn_factory(spike_key):
+    rates = INPUT_RATES
+
+    def fn(t, x, args):
+        step_idx = jnp.asarray(jnp.rint(t / DT), dtype=jnp.int64)
+        spikes_1d = jr.poisson(
+            jr.fold_in(spike_key, step_idx), rates * DT, shape=(1, N_INPUTS)
+        )
+        return jnp.tile(spikes_1d, (N_NEURONS, 1)).astype(jnp.float64)
+
+    return fn
+
+
+def _make_base_network(model_cls, delta_V, key, use_gating=True):
+    kwargs = dict(
+        dt=DT,
+        N_neurons=N_NEURONS,
+        N_inputs=N_INPUTS,
+        initial_weight_matrix=make_initial_weights(),
+        input_types=INPUT_TYPES,
+        fully_connected_input=True,
+        key=key,
+    )
+    if model_cls is GatedLIFNetwork:
+        net = model_cls(**kwargs)
+        object.__setattr__(net, "delta_V", float(delta_V))
+        return net
+    if model_cls is OUAMeanReversionLIFNetwork:
+        return model_cls(
+            **kwargs,
+            delta_V=float(delta_V),
+            use_gating=use_gating,
+            update_clip=1.0,
+        )
+    if model_cls is PerSynapseGatedEligibilityLIFNetwork:
+        return model_cls(**kwargs, delta_V=float(delta_V))
+    raise ValueError(f"Unknown model_cls {model_cls}")
+
+
+def _make_cell(cell_id, delta_V, sigma_pn, sigma_ps, key):
+    net_key, _ = jr.split(key)
+    if cell_id in ("A-PN", "A0-PN"):
+        use_gating = (cell_id == "A-PN")
+        net = _make_base_network(OUAMeanReversionLIFNetwork, delta_V, net_key, use_gating=use_gating)
+        noise = NeuralNoiseOUP(tau=net.tau_E, dim=N_NEURONS, noise_std=sigma_pn)
+        return NoisyNetwork(net, noise, min_noise_std=5e-9), "PN"
+    if cell_id in ("A-PS", "A0-PS"):
+        use_gating = (cell_id == "A-PS")
+        net = _make_base_network(OUAMeanReversionLIFNetwork, delta_V, net_key, use_gating=use_gating)
+        noise = PerSynapseOUP(
+            N_neurons=N_NEURONS, N_inputs=N_INPUTS,
+            excitatory_mask=net.excitatory_mask,
+            tau=net.tau_E, noise_std=sigma_ps,
+        )
+        return PerSynapseNoisyNetwork(net, noise, min_noise_std=5e-9), "PS"
+    if cell_id == "B-PN":
+        net = _make_base_network(GatedLIFNetwork, delta_V, net_key)
+        noise = NeuralNoiseOUP(tau=net.tau_E, dim=N_NEURONS, noise_std=sigma_pn)
+        return NoisyNetwork(net, noise, min_noise_std=5e-9), "PN"
+    if cell_id == "B-PS":
+        net = _make_base_network(PerSynapseGatedEligibilityLIFNetwork, delta_V, net_key)
+        noise = PerSynapseOUP(
+            N_neurons=N_NEURONS, N_inputs=N_INPUTS,
+            excitatory_mask=net.excitatory_mask,
+            tau=net.tau_E, noise_std=sigma_ps,
+        )
+        return PerSynapseNoisyNetwork(net, noise, min_noise_std=5e-9), "PS"
+    raise ValueError(f"Unknown cell {cell_id}")
+
+
+def _make_save_fn(cell_id):
+    def fn(t, y, args):
+        inner = y.network_state
+        common = {
+            "V": inner.V,
+            "S": inner.S,
+            "G_learnable": jnp.atleast_1d(inner.G[0, 4]),
+            "G_bg_E": jnp.atleast_1d(inner.G[0, 2]),    # 5 kHz E input
+            "W_learnable": jnp.atleast_1d(inner.W[0, 4]),
+            "noise_state": y.noise_state,
+            "var_E_n": jnp.atleast_1d(inner.var_E_conductance[0]),
+            "mean_E_n": jnp.atleast_1d(inner.mean_E_conductance[0]),
+        }
+        if cell_id.startswith("B-"):
+            common["eligibility_learnable"] = jnp.atleast_1d(inner.features.eligibility[0, 4])
+        return common
+
+    return fn
+
+
+def _build_args(spike_key, sigma_ps, learning_rate=0.0):
+    return {
+        "get_input_spikes": _input_spike_fn_factory(spike_key),
+        "get_learning_rate": lambda t, x, a: jnp.array(learning_rate),
+        "get_desired_balance": lambda t, x, a: jnp.array(BALANCE_TARGET),
+        "noise_scale_hyperparam": NOISE_SCALE_HYPERPARAM,
+        "use_noise": jnp.array([True, False]),
+        "RPE": jnp.array(0.0),
+        "per_synapse_noise_std_target": sigma_ps,
+    }
+
+
+def run_cell(cell_id, delta_V, seed, sigma_pn, sigma_ps, T=T_TOTAL, learning_rate=0.0):
+    base_key = jr.PRNGKey(seed)
+    cell_key, spike_key, brown_key = jr.split(base_key, 3)
+    wrap, _ = _make_cell(cell_id, delta_V, sigma_pn, sigma_ps, cell_key)
+    args = _build_args(spike_key, sigma_ps, learning_rate=learning_rate)
+    save_ts = jnp.linspace(0.0, T, N_SAVE)
+    saveat = dfx.SaveAt(subs=dfx.SubSaveAt(ts=save_ts, fn=_make_save_fn(cell_id)))
+    return simulate_noisy_SNN(
+        wrap, dfx.EulerHeun(), 0.0, T, DT, wrap.initial,
+        save_at=saveat, args=args, key=brown_key,
+    )
+
+
+def calibrate(T_warm=20.0, seed=MASTER_SEED):
+    """Variance-match calibration using B-PN at the desired operating regime."""
+    key = jr.PRNGKey(seed)
+    net_key, spike_key, brown_key = jr.split(key, 3)
+    net = GatedLIFNetwork(
+        N_neurons=N_NEURONS, N_inputs=N_INPUTS, dt=DT,
+        initial_weight_matrix=make_initial_weights(), input_types=INPUT_TYPES,
+        fully_connected_input=True, key=net_key,
+    )
+    object.__setattr__(net, "delta_V", 1e-3)
+    noise = NeuralNoiseOUP(tau=net.tau_E, dim=N_NEURONS, noise_std=5e-9)
+    wrap = NoisyNetwork(net, noise, min_noise_std=5e-9)
+    args = _build_args(spike_key, 0.0, learning_rate=0.0)
+    save_ts = jnp.linspace(WARMUP_T, T_warm, 400)
+
+    def save_fn(t, y, args):
+        return {
+            "G_E1": jnp.atleast_1d(y.network_state.G[0, 2]),
+            "G_E2": jnp.atleast_1d(y.network_state.G[0, 4]),
+            "var_E": jnp.atleast_1d(y.network_state.var_E_conductance[0]),
+            "V": jnp.atleast_1d(y.network_state.V[0]),
+            "S": jnp.atleast_1d(y.network_state.S[0]),
+        }
+
+    saveat = dfx.SaveAt(subs=dfx.SubSaveAt(ts=save_ts, fn=save_fn))
+    sol = simulate_noisy_SNN(
+        wrap, dfx.EulerHeun(), 0.0, T_warm, DT, wrap.initial,
+        save_at=saveat, args=args, key=brown_key,
+    )
+    G_exc = np.column_stack([
+        np.asarray(sol.ys["G_E1"]).ravel(),
+        np.asarray(sol.ys["G_E2"]).ravel(),
+    ]) / float(net.synaptic_increment)
+    s2_mean = float(np.mean(G_exc ** 2))
+    var_E_ss = float(np.mean(np.asarray(sol.ys["var_E"]).ravel()[-100:]))
+    fr = float(np.mean(np.asarray(sol.ys["S"]).ravel()) / (T_warm - WARMUP_T) * len(np.asarray(sol.ys["S"]).ravel()))
+    V_mean = float(np.mean(np.asarray(sol.ys["V"]).ravel()))
+    sigma_pn = float(np.sqrt(var_E_ss) * NOISE_SCALE_HYPERPARAM + 5e-9)
+    abs_E_i = 2.0
+    sigma_ps = float(sigma_pn / (net.synaptic_increment * np.sqrt(abs_E_i * s2_mean)))
+    return {
+        "sigma_per_neuron": sigma_pn,
+        "sigma_per_synapse": sigma_ps,
+        "abs_E_i": abs_E_i,
+        "s2_mean": s2_mean,
+        "var_E_ss": var_E_ss,
+        "fr_noisy_calib_warmup": fr,
+        "V_mean_noisy_calib": V_mean,
+        "noise_scale_hyperparam": NOISE_SCALE_HYPERPARAM,
+        "balance_target": BALANCE_TARGET,
+        "T_warm": T_warm,
+        "master_seed": MASTER_SEED,
+    }
+
+
+def main():
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    RAW_DIR.mkdir(parents=True, exist_ok=True)
+    print("=" * 78)
+    print("OUA P3-v2 — Single Synapse Task, 6 cells, Eq. 33/34 metrics")
+    print(f"noise_scale={NOISE_SCALE_HYPERPARAM}, balance={BALANCE_TARGET}, T={T_TOTAL}s, dt={DT}s")
+    print(f"DV: {[float(x) for x in DELTA_V_SWEEP]}")
+    print(f"Cells: {CELL_IDS}")
+    print("=" * 78)
+
+    t0 = time.time()
+    calib = calibrate()
+    print(f"[calib] {time.time()-t0:.1f}s")
+    for k, v in calib.items():
+        print(f"  {k}: {v}")
+    with open(RESULTS_DIR / "calibration.json", "w") as fh:
+        json.dump(calib, fh, indent=2)
+    sigma_pn = calib["sigma_per_neuron"]
+    sigma_ps = calib["sigma_per_synapse"]
+
+    n_total = len(CELL_IDS) * len(DELTA_V_SWEEP) * len(SEEDS)
+    print(f"[run] {n_total} simulations")
+    elapsed = 0.0
+    done = 0
+    for cell_id in CELL_IDS:
+        for k, dV in enumerate(DELTA_V_SWEEP):
+            dV_pow = -7 - k
+            for seed in SEEDS:
+                tag = f"{cell_id}_dV2^{dV_pow}_seed{seed}"
+                save_path = RAW_DIR / f"{tag}.npz"
+                if save_path.exists():
+                    done += 1
+                    continue
+                t0 = time.time()
+                try:
+                    sol = run_cell(cell_id, float(dV), seed, sigma_pn, sigma_ps, T=T_TOTAL)
+                except Exception as exc:
+                    print(f"[ERR] {tag}: {type(exc).__name__}: {str(exc)[:150]}")
+                    continue
+                wall = time.time() - t0
+                elapsed += wall
+                done += 1
+                ts = np.asarray(sol.ts)
+                ys = {k: np.asarray(v) for k, v in sol.ys.items()}
+                np.savez(
+                    save_path,
+                    ts=ts, **ys,
+                    cell_id=cell_id, delta_V=float(dV), seed=seed,
+                    sigma_pn=sigma_pn, sigma_ps=sigma_ps,
+                    master_seed=MASTER_SEED,
+                    noise_scale_hyperparam=NOISE_SCALE_HYPERPARAM,
+                    balance_target=BALANCE_TARGET,
+                )
+                fr = float(ys["S"][:, 0].sum() / T_TOTAL)
+                print(f"[done {done}/{n_total}] {tag} wall={wall:.1f}s fr={fr:.2f}Hz")
+    print(f"[total] {elapsed:.1f}s for new runs")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/overnight/run_paired_comparison_v2.py
+++ b/scripts/overnight/run_paired_comparison_v2.py
@@ -48,7 +48,7 @@ from adaptive_SNN.models.networks.per_synapse_noisy_network import (  # noqa: E4
 )
 from adaptive_SNN.models.noise.oup import NeuralNoiseOUP  # noqa: E402
 from adaptive_SNN.models.noise.per_synapse_oup import PerSynapseOUP  # noqa: E402
-from adaptive_SNN.solver import simulate_noisy_SNN  # noqa: E402
+from adaptive_SNN.solver import solve_ODE  # noqa: E402
 
 # ---------------------------------------------------------------------------
 MASTER_SEED = 42
@@ -184,7 +184,7 @@ def run_cell(cell_id, delta_V, seed, sigma_pn, sigma_ps, T=T_TOTAL, learning_rat
     args = _build_args(spike_key, sigma_ps, learning_rate=learning_rate)
     save_ts = jnp.linspace(0.0, T, N_SAVE)
     saveat = dfx.SaveAt(subs=dfx.SubSaveAt(ts=save_ts, fn=_make_save_fn(cell_id)))
-    return simulate_noisy_SNN(
+    return solve_ODE(
         wrap, dfx.EulerHeun(), 0.0, T, DT, wrap.initial,
         save_at=saveat, args=args, key=brown_key,
     )
@@ -215,7 +215,7 @@ def calibrate(T_warm=20.0, seed=MASTER_SEED):
         }
 
     saveat = dfx.SaveAt(subs=dfx.SubSaveAt(ts=save_ts, fn=save_fn))
-    sol = simulate_noisy_SNN(
+    sol = solve_ODE(
         wrap, dfx.EulerHeun(), 0.0, T_warm, DT, wrap.initial,
         save_at=saveat, args=args, key=brown_key,
     )

--- a/scripts/overnight/run_theory_validation.py
+++ b/scripts/overnight/run_theory_validation.py
@@ -52,7 +52,7 @@ from adaptive_SNN.models.networks.per_synapse_noisy_network import (  # noqa: E4
 from adaptive_SNN.models.networks.noisy_network import NoisyNetwork  # noqa: E402
 from adaptive_SNN.models.noise.oup import NeuralNoiseOUP  # noqa: E402
 from adaptive_SNN.models.noise.per_synapse_oup import PerSynapseOUP  # noqa: E402
-from adaptive_SNN.solver import simulate_noisy_SNN  # noqa: E402
+from adaptive_SNN.solver import solve_ODE  # noqa: E402
 
 MASTER_SEED = 42
 N_NEURONS, N_INPUTS = 2, 3
@@ -146,7 +146,7 @@ def run_one(name, agent, args, T):
     save_ts = jnp.linspace(0.0, T, N_SAVE)
     saveat = dfx.SaveAt(subs=dfx.SubSaveAt(ts=save_ts, fn=_save_fn(name)))
     key = jr.PRNGKey(7)
-    return simulate_noisy_SNN(agent, dfx.EulerHeun(), 0.0, T, DT, agent.initial,
+    return solve_ODE(agent, dfx.EulerHeun(), 0.0, T, DT, agent.initial,
                               save_at=saveat, args=args, key=key)
 
 

--- a/scripts/overnight/run_theory_validation.py
+++ b/scripts/overnight/run_theory_validation.py
@@ -1,0 +1,273 @@
+"""Phase D — Theory validation experiments.
+
+Three checks:
+
+1. **τ_e → 0 equivalence (theorist Q9; unified §4.5)**
+   Run B-PS (PerSynapseGatedEligibilityLIFNetwork) with τ_e ∈
+   {τ_E, 3τ_E, 100ms} and compare W trajectories to A-PS (OUA mean-reversion,
+   which is the τ_e → 0 limit). With τ_e = τ_E the two should be statistically
+   indistinguishable on short windows; with τ_e = 100 ms eligibility wins on
+   delayed-reward regimes (no explicit reward delay here so the gap is from
+   the integral kernel itself).
+
+2. **OUA Lyapunov check (theorist Q5)**
+   Run A-PN with η > 0 at very small ΔV (where the gate spikes) — verify the
+   γ-clip prevents W blow-up. Report `clip_engagement_fraction = fraction of
+   timesteps where clip_factor < 1`.
+
+3. **Stein-lemma bias diagnostic (theorist Q4)**
+   From the v2 raw data, compute E[δ_r^task(t) | V_noisy(t) ∈ gate-active
+   region]. If non-zero, the gated estimator is biased per Stein's lemma.
+
+Output: results/overnight-theory-validation/.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import diffrax as dfx  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import jax.random as jr  # noqa: E402
+import numpy as np  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from adaptive_SNN.models.networks.learning_agent import LearningAgent  # noqa: E402
+from adaptive_SNN.models.networks.oua_LIF import OUAMeanReversionLIFNetwork  # noqa: E402
+from adaptive_SNN.models.networks.oua_eligibility_LIF import (  # noqa: E402
+    PerSynapseGatedEligibilityLIFNetwork,
+)
+from adaptive_SNN.models.networks.per_synapse_noisy_network import (  # noqa: E402
+    PerSynapseNoisyNetwork,
+)
+from adaptive_SNN.models.networks.noisy_network import NoisyNetwork  # noqa: E402
+from adaptive_SNN.models.noise.oup import NeuralNoiseOUP  # noqa: E402
+from adaptive_SNN.models.noise.per_synapse_oup import PerSynapseOUP  # noqa: E402
+from adaptive_SNN.solver import simulate_noisy_SNN  # noqa: E402
+
+MASTER_SEED = 42
+N_NEURONS, N_INPUTS = 2, 3
+INPUT_RATES = jnp.array([5000.0, 1250.0, 10.0])
+INPUT_TYPES = jnp.array([True, False, True])
+NOISE_SCALE_HYPERPARAM = 2.0
+BALANCE_TARGET = 0.0
+T_TOTAL = 30.0
+DT = 1e-4
+N_SAVE = 800
+
+RESULTS_DIR = REPO_ROOT / "results" / "overnight-theory-validation"
+RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def make_initial_weights():
+    return jnp.tile(jnp.array([jnp.nan, jnp.nan, 1.1, 11.0, 0.0]), (N_NEURONS, 1))
+
+
+def _input_spike_fn(spike_key):
+    rates = INPUT_RATES
+
+    def fn(t, x, args):
+        step_idx = jnp.asarray(jnp.rint(t / DT), dtype=jnp.int64)
+        spikes_1d = jr.poisson(jr.fold_in(spike_key, step_idx), rates * DT, shape=(1, N_INPUTS))
+        return jnp.tile(spikes_1d, (N_NEURONS, 1)).astype(jnp.float64)
+
+    return fn
+
+
+def _make_oua_per_synapse(delta_V, sigma_ps, key, use_gating=True, update_clip=1.0):
+    net = OUAMeanReversionLIFNetwork(
+        dt=DT, N_neurons=N_NEURONS, N_inputs=N_INPUTS,
+        initial_weight_matrix=make_initial_weights(),
+        input_types=INPUT_TYPES, fully_connected_input=True, key=key,
+        delta_V=float(delta_V), use_gating=use_gating, update_clip=update_clip,
+    )
+    oup = PerSynapseOUP(N_neurons=N_NEURONS, N_inputs=N_INPUTS, excitatory_mask=net.excitatory_mask,
+                        tau=net.tau_E, noise_std=sigma_ps)
+    return PerSynapseNoisyNetwork(net, oup, min_noise_std=5e-9), net
+
+
+def _make_oua_per_neuron(delta_V, sigma_pn, key, use_gating=True, update_clip=1.0):
+    net = OUAMeanReversionLIFNetwork(
+        dt=DT, N_neurons=N_NEURONS, N_inputs=N_INPUTS,
+        initial_weight_matrix=make_initial_weights(),
+        input_types=INPUT_TYPES, fully_connected_input=True, key=key,
+        delta_V=float(delta_V), use_gating=use_gating, update_clip=update_clip,
+    )
+    return NoisyNetwork(net, NeuralNoiseOUP(tau=net.tau_E, dim=N_NEURONS, noise_std=sigma_pn), min_noise_std=5e-9), net
+
+
+def _make_elig_per_synapse(delta_V, sigma_ps, key, tau_eligibility=0.1):
+    net = PerSynapseGatedEligibilityLIFNetwork(
+        dt=DT, N_neurons=N_NEURONS, N_inputs=N_INPUTS,
+        initial_weight_matrix=make_initial_weights(),
+        input_types=INPUT_TYPES, fully_connected_input=True, key=key,
+        tau_eligibility=tau_eligibility, delta_V=float(delta_V),
+    )
+    oup = PerSynapseOUP(N_neurons=N_NEURONS, N_inputs=N_INPUTS, excitatory_mask=net.excitatory_mask,
+                        tau=net.tau_E, noise_std=sigma_ps)
+    return PerSynapseNoisyNetwork(net, oup, min_noise_std=5e-9), net
+
+
+def _build_args(spike_key, rpe_key, sigma_ps, lr):
+    return {
+        "get_input_spikes": _input_spike_fn(spike_key),
+        "get_learning_rate": lambda t, x, a: jnp.array(lr),
+        "get_desired_balance": lambda t, x, a: jnp.array(BALANCE_TARGET),
+        "noise_scale_hyperparam": NOISE_SCALE_HYPERPARAM,
+        "use_noise": jnp.array([True, False]),
+        "per_synapse_noise_std_target": sigma_ps,
+        "rpe_noise_key": rpe_key,
+    }
+
+
+def _save_fn(cell_id):
+    def fn(t, y, args):
+        inner = y.network_state.network_state
+        return {
+            "V": inner.V,
+            "S": inner.S,
+            "W_learn": jnp.atleast_1d(inner.W[0, 4]),
+            "G_learn": jnp.atleast_1d(inner.G[0, 4]),
+            "rpe": jnp.atleast_1d(y.rpe),
+        }
+    return fn
+
+
+def run_one(name, agent, args, T):
+    save_ts = jnp.linspace(0.0, T, N_SAVE)
+    saveat = dfx.SaveAt(subs=dfx.SubSaveAt(ts=save_ts, fn=_save_fn(name)))
+    key = jr.PRNGKey(7)
+    return simulate_noisy_SNN(agent, dfx.EulerHeun(), 0.0, T, DT, agent.initial,
+                              save_at=saveat, args=args, key=key)
+
+
+def experiment_tau_e_equivalence(sigma_pn, sigma_ps, seed=42, T=15.0, lr=50.0):
+    """B-PS at τ_e ∈ {6ms, 30ms, 100ms} vs A-PS reference."""
+    print(f"\n[exp1] τ_e equivalence: A-PS vs B-PS at varying τ_e (T={T}s, lr={lr})")
+    base_key = jr.PRNGKey(seed)
+    cell_key, spike_key, brown_key, rpe_key = jr.split(base_key, 4)
+    delta_V = 2.0 ** -9
+    results = {}
+    # A-PS (OUA reference)
+    noisy_aps, _ = _make_oua_per_synapse(delta_V, sigma_ps, cell_key, use_gating=True)
+    args = _build_args(spike_key, rpe_key, sigma_ps, lr)
+    agent = LearningAgent(noisy_aps)
+    sol = run_one("A-PS", agent, args, T)
+    results["A-PS"] = {k: np.asarray(v) for k, v in sol.ys.items()}
+    results["ts"] = np.asarray(sol.ts)
+    # B-PS at three τ_e values (same key, same setup)
+    for tau_e_ms in [6, 30, 100]:
+        tau_e = tau_e_ms * 1e-3
+        noisy_bps, _ = _make_elig_per_synapse(delta_V, sigma_ps, cell_key, tau_eligibility=tau_e)
+        agent = LearningAgent(noisy_bps)
+        args = _build_args(spike_key, rpe_key, sigma_ps, lr)
+        sol = run_one(f"B-PS-tau{tau_e_ms}ms", agent, args, T)
+        results[f"B-PS_tau{tau_e_ms}ms"] = {k: np.asarray(v) for k, v in sol.ys.items()}
+    np.savez(RESULTS_DIR / "tau_e_equivalence.npz", **{
+        "ts": results["ts"],
+        **{f"{name}__{k}": v for name in results if name != "ts" for k, v in results[name].items()}
+    })
+    print(f"  Saved {RESULTS_DIR / 'tau_e_equivalence.npz'}")
+    # Quick summary: W_learn at end
+    for name in ["A-PS", "B-PS_tau6ms", "B-PS_tau30ms", "B-PS_tau100ms"]:
+        W = results[name]["W_learn"].ravel()
+        print(f"  {name}: W[0]={W[0]:.3e} W[-1]={W[-1]:.3e}")
+
+
+def experiment_lyapunov(sigma_pn, sigma_ps, seed=42, T=20.0, lr=20.0):
+    """A-PN at very small ΔV — clip should engage; W should stay bounded."""
+    print(f"\n[exp2] Lyapunov check: A-PN at tiny ΔV (T={T}s, lr={lr})")
+    base_key = jr.PRNGKey(seed)
+    cell_key, spike_key, brown_key, rpe_key = jr.split(base_key, 4)
+    results = {}
+    for dV_pow in [-13, -11, -9]:
+        delta_V = 2.0 ** dV_pow
+        noisy, _ = _make_oua_per_neuron(delta_V, sigma_pn, cell_key, use_gating=True, update_clip=0.5)
+        agent = LearningAgent(noisy)
+        args = _build_args(spike_key, rpe_key, sigma_ps, lr)
+        sol = run_one(f"A-PN_dV2^{dV_pow}", agent, args, T)
+        ys = {k: np.asarray(v) for k, v in sol.ys.items()}
+        results[f"dV{dV_pow}"] = ys
+        W = ys["W_learn"].ravel()
+        print(f"  dV=2^{dV_pow}: W[0]={W[0]:.3e} W[-1]={W[-1]:.3e} max|W|={np.max(np.abs(W)):.3e}")
+    np.savez(RESULTS_DIR / "lyapunov.npz", ts=np.asarray(sol.ts),
+             **{f"{name}__{k}": v for name, ys in results.items() for k, v in ys.items()})
+    print(f"  Saved {RESULTS_DIR / 'lyapunov.npz'}")
+
+
+def experiment_stein_bias():
+    """Compute E[δ_r^task | V in gate-active region] from v2 raw data."""
+    print("\n[exp3] Stein-lemma bias diagnostic (from v2 data)")
+    v2_raw = REPO_ROOT / "results" / "overnight-single-synapse-v2" / "raw"
+    files = sorted(v2_raw.glob("A-PS_dV2^-9_seed*.npz")) + sorted(v2_raw.glob("B-PN_dV2^-9_seed*.npz"))
+    if not files:
+        print(f"  No v2 files found in {v2_raw} — skipping bias diagnostic")
+        return
+    rows = []
+    for fp in files:
+        z = np.load(fp, allow_pickle=True)
+        ts = z["ts"]
+        V = z["V"][:, 0]
+        S = z["S"]
+        delta_V = float(z["delta_V"])
+        # Gate-active region: V in [V_th - 5*delta_V, V_th + 2*delta_V]
+        V_th = -50e-3
+        gate_active = (V > V_th - 5 * delta_V) & (V < V_th + 2 * delta_V)
+        # δ_r^task = exp-filter of spike diff
+        raw_rpe = (S[:, 0] > 0).astype(float) - (S[:, 1] > 0).astype(float)
+        dt = float(ts[1] - ts[0])
+        alpha = np.exp(-dt / 0.1)
+        rpe = np.zeros_like(raw_rpe)
+        for i in range(1, len(rpe)):
+            rpe[i] = rpe[i - 1] * alpha + raw_rpe[i] * (1 - alpha)
+        # Conditional mean of δ_r given V in gate-active
+        if gate_active.sum() > 10:
+            cond_mean = float(np.mean(rpe[gate_active]))
+            marg_mean = float(np.mean(rpe))
+        else:
+            cond_mean = float("nan")
+            marg_mean = float("nan")
+        rows.append({
+            "file": fp.name,
+            "delta_V": delta_V,
+            "n_gate_active_samples": int(gate_active.sum()),
+            "cond_E_rpe_given_gate": cond_mean,
+            "marg_E_rpe": marg_mean,
+            "bias_proxy": cond_mean - marg_mean,
+        })
+    import csv
+    with open(RESULTS_DIR / "stein_bias.csv", "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+        w.writeheader()
+        w.writerows(rows)
+    print(f"  Saved {RESULTS_DIR / 'stein_bias.csv'} ({len(rows)} files)")
+    for r in rows[:6]:
+        print(f"  {r['file']}: gate-active n={r['n_gate_active_samples']}, "
+              f"E[δ_r|V in gate]={r['cond_E_rpe_given_gate']:.3e}, "
+              f"E[δ_r]={r['marg_E_rpe']:.3e}, bias={r['bias_proxy']:.3e}")
+
+
+def main():
+    from run_paired_comparison_v2 import calibrate
+    calib = calibrate()
+    sigma_pn = calib["sigma_per_neuron"]
+    sigma_ps = calib["sigma_per_synapse"]
+    with open(RESULTS_DIR / "calibration.json", "w") as fh:
+        json.dump(calib, fh, indent=2)
+
+    experiment_tau_e_equivalence(sigma_pn, sigma_ps, T=15.0)
+    experiment_lyapunov(sigma_pn, sigma_ps, T=20.0)
+    experiment_stein_bias()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/overnight/run_tier2_patterns.py
+++ b/scripts/overnight/run_tier2_patterns.py
@@ -54,21 +54,21 @@ from adaptive_SNN.solver import simulate_noisy_SNN  # noqa: E402
 # ---------------------------------------------------------------------------
 # Task parameters (Tier-2; simplified for overnight budget)
 # ---------------------------------------------------------------------------
-N_NEURONS = 200          # reduced from 1000 to fit time budget; balanced 80/20
-N_INPUTS = 40            # reduced from 100; 10 inputs per pattern
+N_NEURONS = 100          # 80 E + 20 I; smaller than impl plan's 1000 to fit budget
+N_INPUTS = 40            # 10 inputs per pattern
 N_PATTERNS = 4
 NEURONS_PER_PATTERN = N_INPUTS // N_PATTERNS  # 10
-HIGH_RATE = 100.0        # Hz (on-pattern input rate)
-LOW_RATE = 5.0           # Hz (off-pattern background rate)
+HIGH_RATE = 100.0        # Hz on-pattern
+LOW_RATE = 5.0           # Hz off-pattern background
 PATTERN_DURATION = 0.5   # s per pattern
-T_TOTAL = 30.0           # 60 trials in total
+T_TOTAL = 20.0           # 40 trials per cell
 DT = 1e-4
-N_SAVE = 600
+N_SAVE = 400
 DELTA_V = 2.0 ** -9
 NOISE_SCALE_HYPERPARAM = 2.0
-BALANCE_TARGET = 1.0     # heterosynaptic rebalancing ON for the network
-SEEDS = [42, 43, 44]     # 3 seeds (reduced from 5 for budget)
-CELL_IDS = ["A-PN", "A-PS", "B-PN", "B-PS"]  # skip gate-off controls to save time
+BALANCE_TARGET = 1.0     # heterosynaptic rebalancing ON
+SEEDS = [42, 43, 44]     # 3 seeds
+CELL_IDS = ["A-PN", "A-PS", "B-PN", "B-PS"]
 
 LEARNING_RATES = {
     "A-PN": 20.0,  "A0-PN": 20.0,
@@ -113,7 +113,7 @@ def _make_base_network(model_cls, key, use_gating=True):
         connection_prob_E=0.1, connection_prob_I=0.2,
         initial_input_weight=0.3, initial_rec_weight=0.3,
         rec_weight_std=0.2,
-        fully_connected_input=False,
+        fully_connected_input=True,            # readout sees ALL inputs (key fix)
         fraction_excitatory_recurrent=0.8,
         fraction_excitatory_input=1.0,
         mean_synaptic_delay=1.5e-3,
@@ -151,6 +151,31 @@ def _make_noisy(cell_id, key, sigma_pn, sigma_ps):
     raise ValueError(cell_id)
 
 
+def _task_rpe_fn_factory(target_pattern):
+    """Pattern-discrimination task RPE.
+
+    Returns a drive of magnitude 1/dt (rate-scale) when the readout neuron
+    fires during the on-target pattern, -1/dt when it fires during an
+    off-target pattern, 0 otherwise. After the LearningAgent's exp-filter
+    with τ_RPE = 100 ms, this produces a +/-1-amplitude smoothly-decaying
+    RPE per readout spike.
+    """
+    inv_dt = jnp.array(1.0 / DT, dtype=jnp.float64)
+    target_p = jnp.array(target_pattern, dtype=jnp.int64)
+
+    def fn(t, state, args):
+        # Current pattern index from time
+        p = jnp.floor(t / PATTERN_DURATION).astype(jnp.int64) % jnp.array(N_PATTERNS, dtype=jnp.int64)
+        multiplier = jnp.where(p == target_p, 1.0, -1.0)
+        # Inner spike vector (LearningAgentState.network_state -> NoisyNetworkState
+        # OR PerSynapseNoisyNetworkState; either way .network_state.S indexes
+        # the LIF spike vector)
+        readout_spike = state.network_state.network_state.S[READOUT_IDX]
+        return readout_spike * multiplier * inv_dt
+
+    return fn
+
+
 def _build_args(spike_key, rpe_key, pattern_seed, sigma_ps, lr, target_pattern):
     use_noise = jnp.ones((N_NEURONS,), dtype=bool)
     return {
@@ -162,19 +187,25 @@ def _build_args(spike_key, rpe_key, pattern_seed, sigma_ps, lr, target_pattern):
         "per_synapse_noise_std_target": sigma_ps,
         "rpe_noise_key": rpe_key,
         "target_pattern": target_pattern,
+        "task_rpe_fn": _task_rpe_fn_factory(target_pattern),
     }
 
 
 def _save_fn(cell_id):
-    """Save coarse state — for a 200-neuron net we can't save full state per step."""
+    """Save coarse state — for a 100-neuron net we can't save full state per step."""
     def fn(t, y, args):
         inner = y.network_state.network_state
+        # Pattern index at this time (saved so the offline analysis can compute
+        # per-pattern firing-rate statistics correctly).
+        p = jnp.floor(t / PATTERN_DURATION).astype(jnp.int64) % jnp.array(N_PATTERNS, dtype=jnp.int64)
         return {
             "fr_readout": jnp.atleast_1d(inner.firing_rate[READOUT_IDX]),
             "rpe": jnp.atleast_1d(y.rpe),
             "V_readout": jnp.atleast_1d(inner.V[READOUT_IDX]),
-            "W_readout_inputs": inner.W[READOUT_IDX, N_NEURONS:],  # input weights to readout
-            "S_sum": jnp.atleast_1d(jnp.sum(inner.S)),  # total spikes per save step
+            "W_readout_inputs": inner.W[READOUT_IDX, N_NEURONS:],
+            "S_readout": jnp.atleast_1d(inner.S[READOUT_IDX]),
+            "S_sum": jnp.atleast_1d(jnp.sum(inner.S)),
+            "pattern_idx": jnp.atleast_1d(p),
         }
     return fn
 

--- a/scripts/overnight/run_tier2_patterns.py
+++ b/scripts/overnight/run_tier2_patterns.py
@@ -1,0 +1,258 @@
+"""Phase E — Tier-2 pattern discrimination (impl plan §5.2).
+
+N = 1000 balanced E/I spiking network, K = 4 input patterns, trained to fire
+pattern-specifically on a designated readout neuron. Tests Prediction 1 of
+unified §9: per-synapse beats per-neuron on temporally extended tasks with
+low effective input dimensionality.
+
+Simplifications for the overnight budget:
+- One readout neuron (rather than 10) per trial — focuses on a clean
+  scalar learning signal.
+- Each pattern is a fixed *high-rate subset* of N_X=100 input neurons; off-pattern
+  inputs stay at background rate. The pattern cycles every 500 ms (one trial)
+  for T = 60 s total → 120 trials.
+- Reward: +1 if the readout neuron fires more during the current target pattern
+  than during off-target patterns. Filtered via τ_RPE = 100 ms.
+- Compared cells: 6 cells as in Phase B (A-PN, A-PS, A0-PN, A0-PS, B-PN, B-PS).
+
+Output: weight trajectories, accuracy per epoch, time-to-criterion.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import diffrax as dfx  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import jax.random as jr  # noqa: E402
+import numpy as np  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from adaptive_SNN.models.networks.gated_LIF import GatedLIFNetwork  # noqa: E402
+from adaptive_SNN.models.networks.learning_agent import LearningAgent  # noqa: E402
+from adaptive_SNN.models.networks.noisy_network import NoisyNetwork  # noqa: E402
+from adaptive_SNN.models.networks.oua_LIF import OUAMeanReversionLIFNetwork  # noqa: E402
+from adaptive_SNN.models.networks.oua_eligibility_LIF import (  # noqa: E402
+    PerSynapseGatedEligibilityLIFNetwork,
+)
+from adaptive_SNN.models.networks.per_synapse_noisy_network import (  # noqa: E402
+    PerSynapseNoisyNetwork,
+)
+from adaptive_SNN.models.noise.oup import NeuralNoiseOUP  # noqa: E402
+from adaptive_SNN.models.noise.per_synapse_oup import PerSynapseOUP  # noqa: E402
+from adaptive_SNN.solver import simulate_noisy_SNN  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Task parameters (Tier-2; simplified for overnight budget)
+# ---------------------------------------------------------------------------
+N_NEURONS = 200          # reduced from 1000 to fit time budget; balanced 80/20
+N_INPUTS = 40            # reduced from 100; 10 inputs per pattern
+N_PATTERNS = 4
+NEURONS_PER_PATTERN = N_INPUTS // N_PATTERNS  # 10
+HIGH_RATE = 100.0        # Hz (on-pattern input rate)
+LOW_RATE = 5.0           # Hz (off-pattern background rate)
+PATTERN_DURATION = 0.5   # s per pattern
+T_TOTAL = 30.0           # 60 trials in total
+DT = 1e-4
+N_SAVE = 600
+DELTA_V = 2.0 ** -9
+NOISE_SCALE_HYPERPARAM = 2.0
+BALANCE_TARGET = 1.0     # heterosynaptic rebalancing ON for the network
+SEEDS = [42, 43, 44]     # 3 seeds (reduced from 5 for budget)
+CELL_IDS = ["A-PN", "A-PS", "B-PN", "B-PS"]  # skip gate-off controls to save time
+
+LEARNING_RATES = {
+    "A-PN": 20.0,  "A0-PN": 20.0,
+    "A-PS": 20.0,  "A0-PS": 20.0,
+    "B-PN": 200.0, "B-PS": 200.0,
+}
+
+READOUT_IDX = 0  # designated readout neuron index
+
+RESULTS_DIR = REPO_ROOT / "results" / "overnight-tier2-patterns"
+RAW_DIR = RESULTS_DIR / "raw"
+
+
+def make_input_rates_fn(spike_key, pattern_seed):
+    """Return input_spike_fn that delivers patterned Poisson input.
+
+    The pattern in effect at time t is `floor(t / PATTERN_DURATION) mod K`.
+    On-pattern subset of input neurons fires at HIGH_RATE; others at LOW_RATE.
+    """
+    rng = np.random.default_rng(pattern_seed)
+    # Pattern assignment: pattern p uses inputs [p*npp : (p+1)*npp]
+    pattern_mask = np.zeros((N_PATTERNS, N_INPUTS), dtype=bool)
+    for p in range(N_PATTERNS):
+        pattern_mask[p, p * NEURONS_PER_PATTERN:(p + 1) * NEURONS_PER_PATTERN] = True
+    pattern_mask_jnp = jnp.asarray(pattern_mask)
+
+    def fn(t, x, args):
+        step_idx = jnp.asarray(jnp.rint(t / DT), dtype=jnp.int64)
+        # Current pattern index
+        p = jnp.asarray(jnp.floor(t / PATTERN_DURATION).astype(jnp.int64) % N_PATTERNS)
+        rates_per_input = jnp.where(pattern_mask_jnp[p], HIGH_RATE, LOW_RATE)  # (N_INPUTS,)
+        # Same input to all postsynaptic neurons
+        spikes = jr.poisson(jr.fold_in(spike_key, step_idx), rates_per_input * DT, shape=(1, N_INPUTS))
+        return jnp.tile(spikes, (N_NEURONS, 1)).astype(jnp.float64)
+
+    return fn
+
+
+def _make_base_network(model_cls, key, use_gating=True):
+    kwargs = dict(
+        dt=DT, N_neurons=N_NEURONS, N_inputs=N_INPUTS,
+        connection_prob_E=0.1, connection_prob_I=0.2,
+        initial_input_weight=0.3, initial_rec_weight=0.3,
+        rec_weight_std=0.2,
+        fully_connected_input=False,
+        fraction_excitatory_recurrent=0.8,
+        fraction_excitatory_input=1.0,
+        mean_synaptic_delay=1.5e-3,
+        key=key,
+    )
+    if model_cls is GatedLIFNetwork:
+        net = model_cls(**kwargs)
+        object.__setattr__(net, "delta_V", float(DELTA_V))
+        return net
+    if model_cls is OUAMeanReversionLIFNetwork:
+        return model_cls(**kwargs, delta_V=float(DELTA_V), use_gating=use_gating, update_clip=1.0)
+    if model_cls is PerSynapseGatedEligibilityLIFNetwork:
+        return model_cls(**kwargs, delta_V=float(DELTA_V))
+    raise ValueError(model_cls)
+
+
+def _make_noisy(cell_id, key, sigma_pn, sigma_ps):
+    net_key, _ = jr.split(key)
+    if cell_id in ("A-PN", "A0-PN"):
+        use_gating = (cell_id == "A-PN")
+        net = _make_base_network(OUAMeanReversionLIFNetwork, net_key, use_gating=use_gating)
+        return NoisyNetwork(net, NeuralNoiseOUP(tau=net.tau_E, dim=N_NEURONS, noise_std=sigma_pn), min_noise_std=5e-9), net
+    if cell_id in ("A-PS", "A0-PS"):
+        use_gating = (cell_id == "A-PS")
+        net = _make_base_network(OUAMeanReversionLIFNetwork, net_key, use_gating=use_gating)
+        oup = PerSynapseOUP(N_neurons=N_NEURONS, N_inputs=N_INPUTS, excitatory_mask=net.excitatory_mask, tau=net.tau_E, noise_std=sigma_ps)
+        return PerSynapseNoisyNetwork(net, oup, min_noise_std=5e-9), net
+    if cell_id == "B-PN":
+        net = _make_base_network(GatedLIFNetwork, net_key)
+        return NoisyNetwork(net, NeuralNoiseOUP(tau=net.tau_E, dim=N_NEURONS, noise_std=sigma_pn), min_noise_std=5e-9), net
+    if cell_id == "B-PS":
+        net = _make_base_network(PerSynapseGatedEligibilityLIFNetwork, net_key)
+        oup = PerSynapseOUP(N_neurons=N_NEURONS, N_inputs=N_INPUTS, excitatory_mask=net.excitatory_mask, tau=net.tau_E, noise_std=sigma_ps)
+        return PerSynapseNoisyNetwork(net, oup, min_noise_std=5e-9), net
+    raise ValueError(cell_id)
+
+
+def _build_args(spike_key, rpe_key, pattern_seed, sigma_ps, lr, target_pattern):
+    use_noise = jnp.ones((N_NEURONS,), dtype=bool)
+    return {
+        "get_input_spikes": make_input_rates_fn(spike_key, pattern_seed),
+        "get_learning_rate": lambda t, x, a: jnp.array(lr),
+        "get_desired_balance": lambda t, x, a: jnp.array(BALANCE_TARGET),
+        "noise_scale_hyperparam": NOISE_SCALE_HYPERPARAM,
+        "use_noise": use_noise,
+        "per_synapse_noise_std_target": sigma_ps,
+        "rpe_noise_key": rpe_key,
+        "target_pattern": target_pattern,
+    }
+
+
+def _save_fn(cell_id):
+    """Save coarse state — for a 200-neuron net we can't save full state per step."""
+    def fn(t, y, args):
+        inner = y.network_state.network_state
+        return {
+            "fr_readout": jnp.atleast_1d(inner.firing_rate[READOUT_IDX]),
+            "rpe": jnp.atleast_1d(y.rpe),
+            "V_readout": jnp.atleast_1d(inner.V[READOUT_IDX]),
+            "W_readout_inputs": inner.W[READOUT_IDX, N_NEURONS:],  # input weights to readout
+            "S_sum": jnp.atleast_1d(jnp.sum(inner.S)),  # total spikes per save step
+        }
+    return fn
+
+
+def run_cell(cell_id, seed, sigma_pn, sigma_ps, T=T_TOTAL):
+    base_key = jr.PRNGKey(seed)
+    cell_key, spike_key, brown_key, rpe_key = jr.split(base_key, 4)
+    noisy, base_net = _make_noisy(cell_id, cell_key, sigma_pn, sigma_ps)
+    agent = LearningAgent(
+        noisy, tau_RPE=0.1, rpe_noise_rate=1.0, rpe_noise_std=1.0,
+        noisy_idx=READOUT_IDX, noiseless_idx=READOUT_IDX,  # placeholder; we'll override RPE below
+    )
+    # For pattern discrimination we don't have a "noiseless twin" — instead the
+    # spike differential is meaningless. We rebuild RPE via the pattern target:
+    # use Spike[READOUT] - mean_other_neurons as the "reward".
+    # NOTE: in this Tier-2 setup, the LearningAgent's built-in RPE drive
+    # (S[0] - S[1]) is a proxy. We accept that as a quick approximation for
+    # the overnight; a proper task-RPE would track readout spike count against
+    # a target pattern. The eligibility-based learning still consolidates noisy
+    # weight changes correlated with rpe drive.
+    target_pattern = 0  # constant; learn to fire on pattern 0
+    args = _build_args(spike_key, rpe_key, seed * 13 + 7, sigma_ps, LEARNING_RATES.get(cell_id, 1.0), target_pattern)
+    save_ts = jnp.linspace(0.0, T, N_SAVE)
+    saveat = dfx.SaveAt(subs=dfx.SubSaveAt(ts=save_ts, fn=_save_fn(cell_id)))
+    return simulate_noisy_SNN(agent, dfx.EulerHeun(), 0.0, T, DT, agent.initial, save_at=saveat, args=args, key=brown_key)
+
+
+def main():
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    RAW_DIR.mkdir(parents=True, exist_ok=True)
+    print("=" * 78)
+    print(f"Phase E — Tier-2 pattern discrimination (N={N_NEURONS}, K={N_PATTERNS} patterns)")
+    print(f"Cells: {CELL_IDS}, T={T_TOTAL}s, seeds: {SEEDS}")
+    print("=" * 78)
+
+    # Tier-2 calibration: a different SST-style calibration; for overnight we
+    # reuse the Phase B-v2 calibration values (sigma_pn ≈ 13.5 nS, sigma_ps ≈ 0.45),
+    # adjusted for the larger network's input drive.
+    sigma_pn = 13.5e-9
+    sigma_ps = 0.45
+
+    n_total = len(CELL_IDS) * len(SEEDS)
+    done = 0
+    elapsed = 0.0
+    for cell_id in CELL_IDS:
+        for seed in SEEDS:
+            tag = f"{cell_id}_seed{seed}"
+            path = RAW_DIR / f"{tag}.npz"
+            if path.exists():
+                done += 1
+                continue
+            t0 = time.time()
+            try:
+                sol = run_cell(cell_id, seed, sigma_pn, sigma_ps, T=T_TOTAL)
+            except Exception as exc:
+                print(f"[ERR] {tag}: {type(exc).__name__}: {str(exc)[:200]}")
+                continue
+            wall = time.time() - t0
+            elapsed += wall
+            done += 1
+            ts = np.asarray(sol.ts)
+            ys = {k: np.asarray(v) for k, v in sol.ys.items()}
+            np.savez(path, ts=ts, **ys, cell_id=cell_id, seed=seed,
+                     N_neurons=N_NEURONS, N_inputs=N_INPUTS, n_patterns=N_PATTERNS,
+                     pattern_duration=PATTERN_DURATION, delta_V=DELTA_V,
+                     sigma_pn=sigma_pn, sigma_ps=sigma_ps,
+                     lr=LEARNING_RATES.get(cell_id, 1.0))
+            W_in = ys["W_readout_inputs"]  # (T, N_INPUTS)
+            print(f"[done {done}/{n_total}] {tag} wall={wall:.1f}s")
+            print(f"  fr_readout last: {float(ys['fr_readout'][-1]):.2f} Hz")
+            print(f"  ⟨W_in pattern0⟩ init→final: "
+                  f"{float(np.mean(W_in[0, :NEURONS_PER_PATTERN])):.3e} → "
+                  f"{float(np.mean(W_in[-1, :NEURONS_PER_PATTERN])):.3e}")
+            print(f"  ⟨W_in others⟩ init→final: "
+                  f"{float(np.mean(W_in[0, NEURONS_PER_PATTERN:])):.3e} → "
+                  f"{float(np.mean(W_in[-1, NEURONS_PER_PATTERN:])):.3e}")
+    print(f"[total] {elapsed:.1f}s new")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/overnight/run_tier2_patterns.py
+++ b/scripts/overnight/run_tier2_patterns.py
@@ -49,7 +49,7 @@ from adaptive_SNN.models.networks.per_synapse_noisy_network import (  # noqa: E4
 )
 from adaptive_SNN.models.noise.oup import NeuralNoiseOUP  # noqa: E402
 from adaptive_SNN.models.noise.per_synapse_oup import PerSynapseOUP  # noqa: E402
-from adaptive_SNN.solver import simulate_noisy_SNN  # noqa: E402
+from adaptive_SNN.solver import solve_ODE  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Task parameters (Tier-2; simplified for overnight budget)
@@ -230,7 +230,7 @@ def run_cell(cell_id, seed, sigma_pn, sigma_ps, T=T_TOTAL):
     args = _build_args(spike_key, rpe_key, seed * 13 + 7, sigma_ps, LEARNING_RATES.get(cell_id, 1.0), target_pattern)
     save_ts = jnp.linspace(0.0, T, N_SAVE)
     saveat = dfx.SaveAt(subs=dfx.SubSaveAt(ts=save_ts, fn=_save_fn(cell_id)))
-    return simulate_noisy_SNN(agent, dfx.EulerHeun(), 0.0, T, DT, agent.initial, save_at=saveat, args=args, key=brown_key)
+    return solve_ODE(agent, dfx.EulerHeun(), 0.0, T, DT, agent.initial, save_at=saveat, args=args, key=brown_key)
 
 
 def main():

--- a/scripts/overnight/run_tier2_patterns_large.py
+++ b/scripts/overnight/run_tier2_patterns_large.py
@@ -1,0 +1,299 @@
+"""Phase E — Tier-2 pattern discrimination at impl-plan-target scale N = 1000.
+
+Identical task structure to run_tier2_patterns.py, scaled up:
+- N = 1000 (800 E + 200 I), p_E = 0.1, p_I = 0.2
+- N_inputs = 100, K = 4 patterns of 25 inputs each
+- T = 10 s (20 trials of 500 ms)
+- 4 cells (A-PN, A-PS, B-PN, B-PS), 2 seeds for tractability
+
+Network-scale calibration: re-runs the SST-style 20s warmup but on a single-
+neuron-of-the-large-network proxy to get appropriate per-neuron / per-synapse
+sigmas at this size and connectivity. Result saved to calibration.json.
+
+Output: results/overnight-tier2-patterns-N1000/raw/{cell_id}_seed{seed}.npz
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import diffrax as dfx  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import jax.random as jr  # noqa: E402
+import numpy as np  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from adaptive_SNN.models.networks.gated_LIF import GatedLIFNetwork  # noqa: E402
+from adaptive_SNN.models.networks.learning_agent import LearningAgent  # noqa: E402
+from adaptive_SNN.models.networks.noisy_network import NoisyNetwork  # noqa: E402
+from adaptive_SNN.models.networks.oua_LIF import OUAMeanReversionLIFNetwork  # noqa: E402
+from adaptive_SNN.models.networks.oua_eligibility_LIF import (  # noqa: E402
+    PerSynapseGatedEligibilityLIFNetwork,
+)
+from adaptive_SNN.models.networks.per_synapse_noisy_network import (  # noqa: E402
+    PerSynapseNoisyNetwork,
+)
+from adaptive_SNN.models.noise.oup import NeuralNoiseOUP  # noqa: E402
+from adaptive_SNN.models.noise.per_synapse_oup import PerSynapseOUP  # noqa: E402
+from adaptive_SNN.solver import simulate_noisy_SNN  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Tier-2 large-scale task parameters (impl plan §5.2 target)
+# ---------------------------------------------------------------------------
+N_NEURONS = 1000
+N_INPUTS = 100
+N_PATTERNS = 4
+NEURONS_PER_PATTERN = N_INPUTS // N_PATTERNS  # 25
+HIGH_RATE = 100.0
+LOW_RATE = 5.0
+PATTERN_DURATION = 0.5
+T_TOTAL = 10.0
+DT = 1e-4
+N_SAVE = 200
+DELTA_V = 2.0 ** -9
+NOISE_SCALE_HYPERPARAM = 2.0
+BALANCE_TARGET = 1.0
+SEEDS = [42, 43]
+CELL_IDS = ["A-PN", "A-PS", "B-PN", "B-PS"]
+
+LEARNING_RATES = {
+    "A-PN": 10.0,  "A-PS": 10.0,
+    "B-PN": 100.0, "B-PS": 100.0,
+}
+
+READOUT_IDX = 0
+
+RESULTS_DIR = REPO_ROOT / "results" / "overnight-tier2-patterns-N1000"
+RAW_DIR = RESULTS_DIR / "raw"
+
+
+def make_input_rates_fn(spike_key, pattern_seed):
+    rng = np.random.default_rng(pattern_seed)
+    pattern_mask = np.zeros((N_PATTERNS, N_INPUTS), dtype=bool)
+    for p in range(N_PATTERNS):
+        pattern_mask[p, p * NEURONS_PER_PATTERN:(p + 1) * NEURONS_PER_PATTERN] = True
+    pattern_mask_jnp = jnp.asarray(pattern_mask)
+
+    def fn(t, x, args):
+        step_idx = jnp.asarray(jnp.rint(t / DT), dtype=jnp.int64)
+        p = jnp.asarray(jnp.floor(t / PATTERN_DURATION).astype(jnp.int64) % N_PATTERNS)
+        rates_per_input = jnp.where(pattern_mask_jnp[p], HIGH_RATE, LOW_RATE)
+        spikes = jr.poisson(jr.fold_in(spike_key, step_idx), rates_per_input * DT, shape=(1, N_INPUTS))
+        return jnp.tile(spikes, (N_NEURONS, 1)).astype(jnp.float64)
+
+    return fn
+
+
+def _make_base_network(model_cls, key, use_gating=True):
+    kwargs = dict(
+        dt=DT, N_neurons=N_NEURONS, N_inputs=N_INPUTS,
+        connection_prob_E=0.1, connection_prob_I=0.2,
+        initial_input_weight=0.3, initial_rec_weight=0.3,
+        rec_weight_std=0.2,
+        fully_connected_input=True,
+        fraction_excitatory_recurrent=0.8,
+        fraction_excitatory_input=1.0,
+        mean_synaptic_delay=1.5e-3,
+        key=key,
+    )
+    if model_cls is GatedLIFNetwork:
+        net = model_cls(**kwargs)
+        object.__setattr__(net, "delta_V", float(DELTA_V))
+        return net
+    if model_cls is OUAMeanReversionLIFNetwork:
+        return model_cls(**kwargs, delta_V=float(DELTA_V), use_gating=use_gating, update_clip=1.0)
+    if model_cls is PerSynapseGatedEligibilityLIFNetwork:
+        return model_cls(**kwargs, delta_V=float(DELTA_V))
+    raise ValueError(model_cls)
+
+
+def _make_noisy(cell_id, key, sigma_pn, sigma_ps):
+    net_key, _ = jr.split(key)
+    if cell_id in ("A-PN", "A0-PN"):
+        use_gating = (cell_id == "A-PN")
+        net = _make_base_network(OUAMeanReversionLIFNetwork, net_key, use_gating=use_gating)
+        return NoisyNetwork(net, NeuralNoiseOUP(tau=net.tau_E, dim=N_NEURONS, noise_std=sigma_pn), min_noise_std=5e-9), net
+    if cell_id in ("A-PS", "A0-PS"):
+        use_gating = (cell_id == "A-PS")
+        net = _make_base_network(OUAMeanReversionLIFNetwork, net_key, use_gating=use_gating)
+        oup = PerSynapseOUP(N_neurons=N_NEURONS, N_inputs=N_INPUTS, excitatory_mask=net.excitatory_mask, tau=net.tau_E, noise_std=sigma_ps)
+        return PerSynapseNoisyNetwork(net, oup, min_noise_std=5e-9), net
+    if cell_id == "B-PN":
+        net = _make_base_network(GatedLIFNetwork, net_key)
+        return NoisyNetwork(net, NeuralNoiseOUP(tau=net.tau_E, dim=N_NEURONS, noise_std=sigma_pn), min_noise_std=5e-9), net
+    if cell_id == "B-PS":
+        net = _make_base_network(PerSynapseGatedEligibilityLIFNetwork, net_key)
+        oup = PerSynapseOUP(N_neurons=N_NEURONS, N_inputs=N_INPUTS, excitatory_mask=net.excitatory_mask, tau=net.tau_E, noise_std=sigma_ps)
+        return PerSynapseNoisyNetwork(net, oup, min_noise_std=5e-9), net
+    raise ValueError(cell_id)
+
+
+def _task_rpe_fn_factory(target_pattern):
+    inv_dt = jnp.array(1.0 / DT, dtype=jnp.float64)
+    target_p = jnp.array(target_pattern, dtype=jnp.int64)
+
+    def fn(t, state, args):
+        p = jnp.floor(t / PATTERN_DURATION).astype(jnp.int64) % jnp.array(N_PATTERNS, dtype=jnp.int64)
+        multiplier = jnp.where(p == target_p, 1.0, -1.0)
+        readout_spike = state.network_state.network_state.S[READOUT_IDX]
+        return readout_spike * multiplier * inv_dt
+
+    return fn
+
+
+def _build_args(spike_key, rpe_key, pattern_seed, sigma_ps, lr, target_pattern):
+    use_noise = jnp.ones((N_NEURONS,), dtype=bool)
+    return {
+        "get_input_spikes": make_input_rates_fn(spike_key, pattern_seed),
+        "get_learning_rate": lambda t, x, a: jnp.array(lr),
+        "get_desired_balance": lambda t, x, a: jnp.array(BALANCE_TARGET),
+        "noise_scale_hyperparam": NOISE_SCALE_HYPERPARAM,
+        "use_noise": use_noise,
+        "per_synapse_noise_std_target": sigma_ps,
+        "rpe_noise_key": rpe_key,
+        "target_pattern": target_pattern,
+        "task_rpe_fn": _task_rpe_fn_factory(target_pattern),
+    }
+
+
+def _save_fn(cell_id):
+    def fn(t, y, args):
+        inner = y.network_state.network_state
+        p = jnp.floor(t / PATTERN_DURATION).astype(jnp.int64) % jnp.array(N_PATTERNS, dtype=jnp.int64)
+        return {
+            "fr_readout": jnp.atleast_1d(inner.firing_rate[READOUT_IDX]),
+            "rpe": jnp.atleast_1d(y.rpe),
+            "V_readout": jnp.atleast_1d(inner.V[READOUT_IDX]),
+            "W_readout_inputs": inner.W[READOUT_IDX, N_NEURONS:],
+            "S_readout": jnp.atleast_1d(inner.S[READOUT_IDX]),
+            "S_sum": jnp.atleast_1d(jnp.sum(inner.S)),
+            "pattern_idx": jnp.atleast_1d(p),
+        }
+    return fn
+
+
+def calibrate_network(T_warm=5.0):
+    """Network-scale warmup: run a B-PN N=1000 network briefly, measure var_E,
+    <s²>, and |E_i| to feed Eq. 11′ for sigma_per_synapse."""
+    print("[calib] N=1000 warmup, T=5s")
+    base_key = jr.PRNGKey(42)
+    cell_key, spike_key, brown_key, rpe_key = jr.split(base_key, 4)
+    noisy, base_net = _make_noisy("B-PN", cell_key, sigma_pn=5e-9, sigma_ps=0.0)
+    args = _build_args(spike_key, rpe_key, 42, 0.0, 0.0, 0)
+    save_ts = jnp.linspace(2.0, T_warm, 60)
+
+    def save_fn(t, y, args):
+        inner = y.network_state.network_state
+        return {
+            "G_inputs": inner.G[READOUT_IDX, N_NEURONS:],
+            "var_E": jnp.atleast_1d(inner.var_E_conductance[READOUT_IDX]),
+            "V": jnp.atleast_1d(inner.V[READOUT_IDX]),
+        }
+
+    agent = LearningAgent(noisy)
+    saveat = dfx.SaveAt(subs=dfx.SubSaveAt(ts=save_ts, fn=save_fn))
+    sol = simulate_noisy_SNN(agent, dfx.EulerHeun(), 0.0, T_warm, DT, agent.initial,
+                             save_at=saveat, args=args, key=brown_key)
+    G_E = np.asarray(sol.ys["G_inputs"]) / float(base_net.synaptic_increment)
+    s2 = float(np.mean(G_E ** 2))
+    var_E = float(np.mean(np.asarray(sol.ys["var_E"]).ravel()[-20:]))
+    V_mean = float(np.mean(np.asarray(sol.ys["V"]).ravel()))
+    sigma_pn = float(np.sqrt(var_E) * NOISE_SCALE_HYPERPARAM + 5e-9)
+    # |E_i| at this network scale: N_inputs (all E) + N_E_rec * p_E
+    abs_E_i = float(N_INPUTS + N_NEURONS * 0.8 * 0.1)
+    sigma_ps = float(sigma_pn / (base_net.synaptic_increment * np.sqrt(abs_E_i * s2)))
+    return {
+        "sigma_per_neuron": sigma_pn,
+        "sigma_per_synapse": sigma_ps,
+        "abs_E_i": abs_E_i,
+        "s2_mean": s2,
+        "var_E_ss": var_E,
+        "V_mean_readout": V_mean,
+        "T_warm": T_warm,
+        "N_neurons": N_NEURONS,
+        "N_inputs": N_INPUTS,
+    }
+
+
+def run_cell(cell_id, seed, sigma_pn, sigma_ps, T=T_TOTAL):
+    base_key = jr.PRNGKey(seed)
+    cell_key, spike_key, brown_key, rpe_key = jr.split(base_key, 4)
+    noisy, base_net = _make_noisy(cell_id, cell_key, sigma_pn, sigma_ps)
+    agent = LearningAgent(noisy, tau_RPE=0.1, rpe_noise_rate=1.0, rpe_noise_std=1.0,
+                          noisy_idx=READOUT_IDX, noiseless_idx=READOUT_IDX)
+    target_pattern = 0
+    args = _build_args(spike_key, rpe_key, seed * 13 + 7, sigma_ps,
+                       LEARNING_RATES.get(cell_id, 1.0), target_pattern)
+    save_ts = jnp.linspace(0.0, T, N_SAVE)
+    saveat = dfx.SaveAt(subs=dfx.SubSaveAt(ts=save_ts, fn=_save_fn(cell_id)))
+    return simulate_noisy_SNN(agent, dfx.EulerHeun(), 0.0, T, DT, agent.initial,
+                              save_at=saveat, args=args, key=brown_key)
+
+
+def main():
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    RAW_DIR.mkdir(parents=True, exist_ok=True)
+    print("=" * 78)
+    print(f"Tier-2 LARGE — N={N_NEURONS}, K={N_PATTERNS}, T={T_TOTAL}s, "
+          f"cells={CELL_IDS}, seeds={SEEDS}")
+    print("=" * 78)
+
+    t0 = time.time()
+    calib = calibrate_network(T_warm=5.0)
+    print(f"[calib] {time.time()-t0:.1f}s")
+    for k, v in calib.items():
+        print(f"  {k}: {v}")
+    with open(RESULTS_DIR / "calibration.json", "w") as fh:
+        json.dump(calib, fh, indent=2)
+    sigma_pn = calib["sigma_per_neuron"]
+    sigma_ps = calib["sigma_per_synapse"]
+
+    n_total = len(CELL_IDS) * len(SEEDS)
+    done = 0
+    elapsed = 0.0
+    for cell_id in CELL_IDS:
+        for seed in SEEDS:
+            tag = f"{cell_id}_seed{seed}"
+            path = RAW_DIR / f"{tag}.npz"
+            if path.exists():
+                done += 1
+                continue
+            t0 = time.time()
+            try:
+                sol = run_cell(cell_id, seed, sigma_pn, sigma_ps, T=T_TOTAL)
+            except Exception as exc:
+                print(f"[ERR] {tag}: {type(exc).__name__}: {str(exc)[:200]}")
+                continue
+            wall = time.time() - t0
+            elapsed += wall
+            done += 1
+            ts = np.asarray(sol.ts)
+            ys = {k: np.asarray(v) for k, v in sol.ys.items()}
+            np.savez(path, ts=ts, **ys,
+                     cell_id=cell_id, seed=seed,
+                     N_neurons=N_NEURONS, N_inputs=N_INPUTS, n_patterns=N_PATTERNS,
+                     pattern_duration=PATTERN_DURATION, delta_V=DELTA_V,
+                     sigma_pn=sigma_pn, sigma_ps=sigma_ps,
+                     lr=LEARNING_RATES.get(cell_id, 1.0))
+            W_in = ys["W_readout_inputs"]
+            fr_init = float(ys["fr_readout"][:10].mean())
+            fr_final = float(ys["fr_readout"][-10:].mean())
+            W_target = float(W_in[-1, :NEURONS_PER_PATTERN].mean())
+            W_off = float(W_in[-1, NEURONS_PER_PATTERN:].mean())
+            print(f"[done {done}/{n_total}] {tag} wall={wall:.1f}s "
+                  f"fr {fr_init:.1f}→{fr_final:.1f}Hz, "
+                  f"W_tgt={W_target:.3e} W_off={W_off:.3e} sel={W_target-W_off:+.3e}")
+    print(f"[total] {elapsed:.1f}s new")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/overnight/run_tier2_patterns_large.py
+++ b/scripts/overnight/run_tier2_patterns_large.py
@@ -44,7 +44,7 @@ from adaptive_SNN.models.networks.per_synapse_noisy_network import (  # noqa: E4
 )
 from adaptive_SNN.models.noise.oup import NeuralNoiseOUP  # noqa: E402
 from adaptive_SNN.models.noise.per_synapse_oup import PerSynapseOUP  # noqa: E402
-from adaptive_SNN.solver import simulate_noisy_SNN  # noqa: E402
+from adaptive_SNN.solver import solve_ODE  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Tier-2 large-scale task parameters (impl plan §5.2 target)
@@ -209,7 +209,7 @@ def calibrate_network(T_warm=5.0):
 
     agent = LearningAgent(noisy)
     saveat = dfx.SaveAt(subs=dfx.SubSaveAt(ts=save_ts, fn=save_fn))
-    sol = simulate_noisy_SNN(agent, dfx.EulerHeun(), 0.0, T_warm, DT, agent.initial,
+    sol = solve_ODE(agent, dfx.EulerHeun(), 0.0, T_warm, DT, agent.initial,
                              save_at=saveat, args=args, key=brown_key)
     G_E = np.asarray(sol.ys["G_inputs"]) / float(base_net.synaptic_increment)
     s2 = float(np.mean(G_E ** 2))
@@ -243,7 +243,7 @@ def run_cell(cell_id, seed, sigma_pn, sigma_ps, T=T_TOTAL):
                        LEARNING_RATES.get(cell_id, 1.0), target_pattern)
     save_ts = jnp.linspace(0.0, T, N_SAVE)
     saveat = dfx.SaveAt(subs=dfx.SubSaveAt(ts=save_ts, fn=_save_fn(cell_id)))
-    return simulate_noisy_SNN(agent, dfx.EulerHeun(), 0.0, T, DT, agent.initial,
+    return solve_ODE(agent, dfx.EulerHeun(), 0.0, T, DT, agent.initial,
                               save_at=saveat, args=args, key=brown_key)
 
 

--- a/scripts/overnight/run_tier2_patterns_large.py
+++ b/scripts/overnight/run_tier2_patterns_large.py
@@ -49,7 +49,15 @@ from adaptive_SNN.solver import simulate_noisy_SNN  # noqa: E402
 # ---------------------------------------------------------------------------
 # Tier-2 large-scale task parameters (impl plan §5.2 target)
 # ---------------------------------------------------------------------------
-N_NEURONS = 1000
+N_NEURONS = 500          # impl plan §5.2 target is 1000; CPU JIT-compilation
+                         # hits a wall at N=1000 (no progress in 1h wall clock).
+                         # N=500 is the practical maximum on this hardware
+                         # without GPU/HPC. The conclusions about per-synapse
+                         # advantage at large N apply qualitatively at N=500
+                         # as long as |E_i| (number of E synapses per neuron)
+                         # grows commensurately, which it does: with p_E=0.1
+                         # and fully-connected inputs, |E_i| = 0.8*500*0.1 + 100
+                         # = 40 + 100 = 140 (vs |E_i|=180 at N=1000).
 N_INPUTS = 100
 N_PATTERNS = 4
 NEURONS_PER_PATTERN = N_INPUTS // N_PATTERNS  # 25
@@ -58,7 +66,7 @@ LOW_RATE = 5.0
 PATTERN_DURATION = 0.5
 T_TOTAL = 10.0
 DT = 1e-4
-N_SAVE = 200
+N_SAVE = 100
 DELTA_V = 2.0 ** -9
 NOISE_SCALE_HYPERPARAM = 2.0
 BALANCE_TARGET = 1.0

--- a/src/adaptive_SNN/models/networks/__init__.py
+++ b/src/adaptive_SNN/models/networks/__init__.py
@@ -2,12 +2,18 @@ from adaptive_SNN.models.networks.agent import Agent, AgentState
 from adaptive_SNN.models.networks.base import AbstractLIFNetwork, LIFState
 from adaptive_SNN.models.networks.default_LIF import LIFNetwork
 from adaptive_SNN.models.networks.noisy_network import NoisyNetwork, NoisyNetworkState
+from adaptive_SNN.models.networks.per_synapse_noisy_network import (
+    PerSynapseNoisyNetwork,
+    PerSynapseNoisyNetworkState,
+)
 
 __all__ = [
     "Agent",
     "AgentState",
     "NoisyNetwork",
     "NoisyNetworkState",
+    "PerSynapseNoisyNetwork",
+    "PerSynapseNoisyNetworkState",
     "AbstractLIFNetwork",
     "LIFState",
     "LIFNetwork",

--- a/src/adaptive_SNN/models/networks/_gating.py
+++ b/src/adaptive_SNN/models/networks/_gating.py
@@ -1,0 +1,45 @@
+"""Shared voltage-gating function for credit assignment.
+
+This is the per-neuron gate gamma(V_i) of unified §3.4 Eq. 3.8 / Alexander Eq. 28.
+Both GatedLIFNetwork (eligibility-trace + gate) and OUAMeanReversionLIFNetwork
+(OUA mean-reversion + gate) import this module-level function so that the gate
+definition lives in one place.
+
+The gate is normalised so that its integral over [V_rest, V_th] equals
+(V_th - V_rest) -- the area under a constant-1 default gate. This means
+average update magnitudes are comparable across delta_V settings.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from jaxtyping import Array
+
+
+def voltage_gate(
+    voltage: Array,
+    delta_V: float | Array,
+    reversal_potential_E: float,
+    firing_threshold: float,
+    resting_potential: float,
+) -> Array:
+    """Voltage-gating function (Alexander Eq. 28; unified Eq. 3.8).
+
+    gamma(V) = (E_E - V) / dV * exp((V - V_th) / dV)
+
+    then normalised by (area / default_area) where default_area = V_th - V_rest.
+    """
+    default_area = 1.0 * (firing_threshold - resting_potential)
+    driving_force = reversal_potential_E - voltage
+
+    def integral(V_):
+        return (reversal_potential_E + delta_V - V_) * -jnp.exp(
+            (V_ - firing_threshold) / delta_V
+        )
+
+    area = integral(resting_potential) - integral(firing_threshold)
+    gating = (
+        driving_force / delta_V * jnp.exp((voltage - firing_threshold) / delta_V)
+    )
+    normalization_factor = area / default_area
+    return gating / normalization_factor

--- a/src/adaptive_SNN/models/networks/base.py
+++ b/src/adaptive_SNN/models/networks/base.py
@@ -458,16 +458,26 @@ class AbstractLIFNetwork(NeuronModelABC):
         # Compute leak current
         leak_current = -self.leak_conductance * (V - self.resting_potential)
 
-        # Compute E/I currents from recurrent connections
-        weighted_conductances = (
-            jnp.where(jnp.isnan(W), 0.0, W) * G
-        )  # For non-existing connections, set weighted conductance to 0
+        # Per-synapse multiplicative-on-weight noise (unified §2.1, Eq. 2.1a):
+        # effective W = (W + zeta) where zeta is masked to excitatory synapses
+        # by the PerSynapseOUP. When the per-synapse noise term is absent the
+        # behaviour reduces exactly to the original additive-on-aggregate
+        # per-neuron path.
+        E_noise_per_synapse = args.get(
+            "per_synapse_excitatory_noise", jnp.zeros_like(W)
+        )
+
+        effective_W = jnp.where(jnp.isnan(W), 0.0, W + E_noise_per_synapse)
+        weighted_conductances = effective_W * G
+
         total_I_conductances = jnp.sum(
             weighted_conductances * jnp.invert(self.excitatory_mask[None, :]), axis=1
         )
         synaptic_E_conductances = jnp.sum(
             weighted_conductances * self.excitatory_mask[None, :], axis=1
         )
+
+        # Per-neuron noise (Alexander's existing additive-on-aggregate path).
         E_noise = args.get("excitatory_noise", jnp.zeros((self.N_neurons,)))
         total_E_conductances = (
             synaptic_E_conductances + E_noise

--- a/src/adaptive_SNN/models/networks/gated_LIF.py
+++ b/src/adaptive_SNN/models/networks/gated_LIF.py
@@ -2,6 +2,7 @@ import jax
 from jax import numpy as jnp
 from jaxtyping import Array
 
+from adaptive_SNN.models.networks._gating import voltage_gate
 from adaptive_SNN.models.networks.base import AbstractLIFNetwork
 from adaptive_SNN.models.networks.eligibility_LIF import ElibilityState, Eligibility
 from adaptive_SNN.utils.operators import DefaultIfNone, ElementWiseMul
@@ -58,24 +59,14 @@ class GatedLIFNetwork(AbstractLIFNetwork):
         return Eligibility(eligibility=None)
 
     def gating_function(self, voltage: Array, delta_V: float) -> Array:
-        """Gating function based on membrane voltage."""
-        default_area = 1.0 * (
-            self.firing_threshold - self.resting_potential
-        )  # Area under the default gating function (which is constant at 1)
-        driving_force = self.reversal_potential_E - voltage
-
-        integral = lambda V: (self.reversal_potential_E + delta_V - V) * -jnp.exp(
-            (V - self.firing_threshold) / delta_V
+        """Voltage-gating function (delegates to shared module-level fn)."""
+        return voltage_gate(
+            voltage,
+            delta_V,
+            reversal_potential_E=self.reversal_potential_E,
+            firing_threshold=self.firing_threshold,
+            resting_potential=self.resting_potential,
         )
-        area = integral(self.resting_potential) - integral(self.firing_threshold)
-        gating = (
-            driving_force
-            / delta_V
-            * jnp.exp((voltage - self.firing_threshold) / delta_V)
-        )
-        normalization_factor = area / default_area
-
-        return gating / normalization_factor
 
     def compute_weight_updates(self, t, state: ElibilityState, args):
         # Compute weight changes

--- a/src/adaptive_SNN/models/networks/learning_agent.py
+++ b/src/adaptive_SNN/models/networks/learning_agent.py
@@ -1,0 +1,147 @@
+"""LearningAgent wrapper — couples a NoisyNetwork / PerSynapseNoisyNetwork with
+a scalar filtered RPE state and a Poisson-noise RPE source.
+
+This is a minimal alternative to the full Agent / AgentEnvSystem stack — built
+so the overnight learning-dynamics experiments can run η > 0 closed-loop with
+δ_r(t) = exp_filter(spike_diff + reward_noise, τ_RPE) without modifying any
+upstream classes.
+"""
+
+from __future__ import annotations
+
+import diffrax as dfx
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from jaxtyping import Array
+
+from adaptive_SNN.models.networks.base import NeuronModelABC
+from adaptive_SNN.utils.operators import DefaultIfNone, ElementWiseMul, MixedPyTreeOperator
+
+default_float = jnp.float64 if jax.config.jax_enable_x64 else jnp.float32
+
+
+class LearningAgentState(eqx.Module):
+    network_state: object       # NoisyNetworkState or PerSynapseNoisyNetworkState
+    rpe: Array                  # scalar filtered RPE
+
+
+class LearningAgent(NeuronModelABC):
+    """Wraps a noisy network and evolves a filtered scalar RPE state.
+
+    The RPE drift is
+        d(RPE)/dt = (-RPE + spike_diff + reward_noise_drive) / tau_RPE
+    where spike_diff = S[0] - S[1] (noisy minus noiseless), and
+    reward_noise_drive is sampled per step from a Poisson process at
+    `rpe_noise_rate` Hz with Gaussian jump magnitude std=`rpe_noise_std`.
+
+    The filtered RPE is exposed to the wrapped network as args["RPE"], so
+    eligibility and OUA cells consume it via their standard
+    compute_weight_updates path.
+    """
+
+    noisy_network: NeuronModelABC
+    tau_RPE: float = 0.1
+    rpe_noise_rate: float = 1.0
+    rpe_noise_std: float = 1.0
+    noisy_idx: int = 0       # row of S corresponding to the noisy neuron
+    noiseless_idx: int = 1   # row of S corresponding to the noiseless reference
+
+    def __init__(
+        self,
+        noisy_network: NeuronModelABC,
+        tau_RPE: float = 0.1,
+        rpe_noise_rate: float = 1.0,
+        rpe_noise_std: float = 1.0,
+        noisy_idx: int = 0,
+        noiseless_idx: int = 1,
+    ):
+        self.noisy_network = noisy_network
+        self.tau_RPE = tau_RPE
+        self.rpe_noise_rate = rpe_noise_rate
+        self.rpe_noise_std = rpe_noise_std
+        self.noisy_idx = noisy_idx
+        self.noiseless_idx = noiseless_idx
+
+    @property
+    def initial(self):
+        return LearningAgentState(
+            network_state=self.noisy_network.initial,
+            rpe=jnp.zeros((), dtype=default_float),
+        )
+
+    def _poisson_jump(self, t, rpe_noise_key):
+        """Approximate Poisson-jump reward noise per timestep.
+
+        Treats the inter-step interval as one Bernoulli trial with success
+        probability `rate * dt`, where `dt` is inferred from the time
+        increment. We rely on the simulator stepping at a fixed dt; we use
+        a per-step key derived from time index.
+        """
+        rng = jr.fold_in(rpe_noise_key, jnp.asarray(jnp.rint(t * 1e4), dtype=jnp.int64))
+        u = jr.uniform(rng)
+        # Probability of a Poisson event per step:
+        p_event = self.rpe_noise_rate * jnp.array(1e-4, dtype=default_float)
+        jump = jnp.where(u < p_event, jr.normal(jr.fold_in(rng, 1)) * self.rpe_noise_std, 0.0)
+        return jump
+
+    def drift(self, t, state: LearningAgentState, args: dict):
+        rpe_key = args.get("rpe_noise_key", jr.PRNGKey(0))
+        # Inject the current filtered RPE so the wrapped network's
+        # consolidation rule consumes it.
+        args = dict(args)
+        args["RPE"] = state.rpe
+
+        # Wrapped network drift (handles its own per-synapse noise routing).
+        net_drift = self.noisy_network.drift(t, state.network_state, args)
+
+        # Spike differential between noisy and noiseless neurons at *current* state.
+        inner = state.network_state.network_state
+        spike_diff = inner.S[self.noisy_idx] - inner.S[self.noiseless_idx]
+        # Convert spike count (already binary in the LIF model) into a delta.
+        # Spikes are events with infinite peak instantaneous rate when filtered
+        # through dt; we approximate the drive as (spike_diff / dt) so the
+        # integral of the exp-filter receives one spike worth per fire.
+        spike_drive = spike_diff / jnp.array(1e-4, dtype=default_float)
+
+        # Poisson reward noise.
+        rpe_noise_jump = self._poisson_jump(t, rpe_key)
+        rpe_noise_drive = rpe_noise_jump / jnp.array(1e-4, dtype=default_float)
+
+        d_rpe = (-state.rpe + spike_drive + rpe_noise_drive) / self.tau_RPE
+        return LearningAgentState(network_state=net_drift, rpe=d_rpe)
+
+    def diffusion(self, t, state: LearningAgentState, args: dict):
+        net_diff = self.noisy_network.diffusion(t, state.network_state, args)
+        return MixedPyTreeOperator(
+            LearningAgentState(
+                network_state=net_diff,
+                rpe=DefaultIfNone(
+                    default=jnp.zeros_like(state.rpe),
+                    else_do=ElementWiseMul(jnp.zeros_like(state.rpe, dtype=default_float)),
+                ),
+            )
+        )
+
+    @property
+    def noise_shape(self):
+        return LearningAgentState(
+            network_state=self.noisy_network.noise_shape,
+            rpe=None,
+        )
+
+    def terms(self, key):
+        process_noise = dfx.UnsafeBrownianPath(
+            shape=self.noise_shape, key=key, levy_area=dfx.SpaceTimeLevyArea
+        )
+        return dfx.MultiTerm(
+            dfx.ODETerm(self.drift), dfx.ControlTerm(self.diffusion, process_noise)
+        )
+
+    def update(self, t, state: LearningAgentState, args):
+        # Inject current RPE into args so the wrapped network's `update` sees it.
+        args = dict(args)
+        args["RPE"] = state.rpe
+        new_net = self.noisy_network.update(t, state.network_state, args)
+        return LearningAgentState(network_state=new_net, rpe=state.rpe)

--- a/src/adaptive_SNN/models/networks/learning_agent.py
+++ b/src/adaptive_SNN/models/networks/learning_agent.py
@@ -96,20 +96,23 @@ class LearningAgent(NeuronModelABC):
         # Wrapped network drift (handles its own per-synapse noise routing).
         net_drift = self.noisy_network.drift(t, state.network_state, args)
 
-        # Spike differential between noisy and noiseless neurons at *current* state.
+        # Task-RPE drive: user-callable via args["task_rpe_fn"] takes priority over
+        # the built-in `S[noisy_idx] - S[noiseless_idx]` fallback (used for SST).
         inner = state.network_state.network_state
-        spike_diff = inner.S[self.noisy_idx] - inner.S[self.noiseless_idx]
-        # Convert spike count (already binary in the LIF model) into a delta.
-        # Spikes are events with infinite peak instantaneous rate when filtered
-        # through dt; we approximate the drive as (spike_diff / dt) so the
-        # integral of the exp-filter receives one spike worth per fire.
-        spike_drive = spike_diff / jnp.array(1e-4, dtype=default_float)
+        task_rpe_fn = args.get("task_rpe_fn", None)
+        if task_rpe_fn is None:
+            spike_diff = inner.S[self.noisy_idx] - inner.S[self.noiseless_idx]
+            task_drive = spike_diff / jnp.array(1e-4, dtype=default_float)
+        else:
+            # Convention: task_rpe_fn returns a *spike-rate-scale* drive
+            # (e.g., +/-1 with a 1/dt-equivalent magnitude already applied).
+            task_drive = task_rpe_fn(t, state, args)
 
         # Poisson reward noise.
         rpe_noise_jump = self._poisson_jump(t, rpe_key)
         rpe_noise_drive = rpe_noise_jump / jnp.array(1e-4, dtype=default_float)
 
-        d_rpe = (-state.rpe + spike_drive + rpe_noise_drive) / self.tau_RPE
+        d_rpe = (-state.rpe + task_drive + rpe_noise_drive) / self.tau_RPE
         return LearningAgentState(network_state=net_drift, rpe=d_rpe)
 
     def diffusion(self, t, state: LearningAgentState, args: dict):

--- a/src/adaptive_SNN/models/networks/oua_LIF.py
+++ b/src/adaptive_SNN/models/networks/oua_LIF.py
@@ -96,24 +96,44 @@ class OUAMeanReversionLIFNetwork(AbstractLIFNetwork):
         Update rule (unified §4.5 / impl plan §4.4):
             dW_ij = eta * delta_r * (zeta_ij / sigma_E) * (G_ij / w0) * gate(V_i)
 
-        with gamma-clip applied multiplicatively on the per-neuron prefactor.
+        Per-synapse geometry (alpha = 1): zeta_ij comes from
+        args["per_synapse_excitatory_noise"] (PerSynapseOUP via
+        PerSynapseNoisyNetwork).
+
+        Per-neuron geometry (alpha = 0): xi_i comes from
+        args["excitatory_noise"] (NeuralNoiseOUP via NoisyNetwork). The
+        per-neuron OUA update is then
+            dW_ij = eta * delta_r * (xi_i / sigma_xi) * (G_ij / w0) * mask_j * gate(V_i)
+        which is the alpha=0 endpoint of unified Eq. 2.4 evaluated under the
+        multiplicative-on-weight excursion (the share xi_i / |E_i| is the
+        per-synapse marginal of the per-neuron noise, but we factor |E_i|
+        into sigma normalisation rather than into the noise term, leaving
+        relative_noise = xi_i / sigma_xi as the natural ratio).
+
+        gamma-clip is applied multiplicatively on the per-neuron prefactor.
         """
         learning_rate = args["get_learning_rate"](t, state, args)
         RPE = args.get("RPE", jnp.array(0.0))
 
-        # zeta_ij — the per-synapse OU excursion.
-        per_synapse_noise = args.get(
-            "per_synapse_excitatory_noise", jnp.zeros_like(state.G)
-        )
-        # Normalise by the OU diffusion strength so the update scale is
-        # invariant to the absolute noise level (matches the analogous
-        # normalisation in EligibilityLIFNetwork.compute_feature_drift).
-        per_synapse_noise_std = args.get("per_synapse_noise_std", 0.0)
-        relative_noise = jnp.where(
-            per_synapse_noise_std != 0.0,
-            per_synapse_noise / per_synapse_noise_std,
-            0.0,
-        )
+        # Prefer per-synapse routing when present (alpha = 1 endpoint).
+        per_synapse_noise = args.get("per_synapse_excitatory_noise", None)
+        if per_synapse_noise is None:
+            # Per-neuron fallback (alpha = 0): broadcast xi_i across excitatory
+            # synapses; the variance match is encoded in sigma_xi normalisation.
+            xi = args.get("excitatory_noise", jnp.zeros((self.N_neurons,)))
+            sigma_xi = args.get("noise_std", 0.0)
+            exc_mask = self.excitatory_mask.astype(state.G.dtype)
+            sigma_xi_arr = jnp.atleast_1d(sigma_xi)
+            sigma_xi_arr = jnp.broadcast_to(sigma_xi_arr, (self.N_neurons,))
+            rel_per_neuron = jnp.where(sigma_xi_arr != 0.0, xi / sigma_xi_arr, 0.0)
+            relative_noise = rel_per_neuron[:, None] * exc_mask[None, :]
+        else:
+            per_synapse_noise_std = args.get("per_synapse_noise_std", 0.0)
+            relative_noise = jnp.where(
+                per_synapse_noise_std != 0.0,
+                per_synapse_noise / per_synapse_noise_std,
+                0.0,
+            )
 
         # s_ij — synaptic activity (G / w0).
         s_ij = state.G / self.synaptic_increment

--- a/src/adaptive_SNN/models/networks/oua_LIF.py
+++ b/src/adaptive_SNN/models/networks/oua_LIF.py
@@ -1,0 +1,150 @@
+"""OUA mean-reversion consolidation rule (unified §4.1, impl plan §4.4).
+
+Under the multiplicative-on-weight noise convention (unified §2.1, Eq. 2.1a)
+the OUA mean-reversion update is the tau_e -> 0 limit of the eligibility
+trace rule (unified §4.5, theorist Q9):
+
+    dW_ij/dt = eta * delta_r * zeta_ij * s_ij * gamma(V_i)
+
+where
+    zeta_ij = args["per_synapse_excitatory_noise"]        (the OU excursion)
+    s_ij    = state.G[i, j] / synaptic_increment           (synaptic activity)
+    gamma   = voltage_gate(V_i, delta_V)  if use_gating, else 1
+
+A mandatory a-priori clip on the per-step update prefactor protects against
+surrogate-spike excursions where the gate can transiently blow up as
+delta_V -> 0 (theorist Q5; impl plan §4.4). The clip bounds
+    |eta * delta_r * gate * clip_factor| <= update_clip.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.random as jr
+from jax import numpy as jnp
+from jaxtyping import Array
+
+from adaptive_SNN.models.networks._gating import voltage_gate
+from adaptive_SNN.models.networks.base import AbstractLIFNetwork, LIFState
+from adaptive_SNN.models.networks.default_LIF import NoFeatures
+from adaptive_SNN.utils.operators import DefaultIfNone, ElementWiseMul
+
+
+class OUAMeanReversionLIFNetwork(AbstractLIFNetwork):
+    """Per-synapse OUA mean-reversion rule with optional voltage gating.
+
+    Attributes
+    ----------
+    delta_V : float
+        Gating steepness. Smaller delta_V -> narrower, taller gate.
+    use_gating : bool
+        If False, gate is identically 1 and the clip is inactive.
+    update_clip : float
+        Absolute upper bound on |eta * delta_r * gate(V_i)| per timestep
+        (per neuron, applied before multiplication by noise * activity).
+        Theorist Q5: protects against transient gate blow-up in the
+        surrogate-spike regime.
+    """
+
+    delta_V: float = 1.0e-3
+    use_gating: bool = True
+    update_clip: float = 1.0
+
+    def __init__(
+        self,
+        dt,
+        N_neurons: int,
+        N_inputs: int = 0,
+        delta_V: float = 1.0e-3,
+        use_gating: bool = True,
+        update_clip: float = 1.0,
+        key: jr.PRNGKey = jr.PRNGKey(0),
+        **parent_kwargs,
+    ):
+        super().__init__(dt=dt, N_neurons=N_neurons, N_inputs=N_inputs, key=key, **parent_kwargs)
+        self.delta_V = delta_V
+        self.use_gating = use_gating
+        self.update_clip = update_clip
+
+    def init_features(self) -> NoFeatures:
+        return NoFeatures()
+
+    def compute_feature_diffusion(self, t, state: LIFState, args) -> NoFeatures:
+        return NoFeatures()
+
+    def compute_feature_drift(self, t, state: LIFState, args) -> NoFeatures:
+        return NoFeatures()
+
+    def compute_feature_update(self, t, state, args) -> NoFeatures:
+        return NoFeatures()
+
+    def noise_shape_features(self) -> NoFeatures:
+        return NoFeatures()
+
+    def gating_function(self, voltage: Array, delta_V: float | Array) -> Array:
+        return voltage_gate(
+            voltage,
+            delta_V,
+            reversal_potential_E=self.reversal_potential_E,
+            firing_threshold=self.firing_threshold,
+            resting_potential=self.resting_potential,
+        )
+
+    def compute_weight_updates(self, t, state: LIFState, args):
+        """OUA mean-reversion weight update.
+
+        Update rule (unified §4.5 / impl plan §4.4):
+            dW_ij = eta * delta_r * (zeta_ij / sigma_E) * (G_ij / w0) * gate(V_i)
+
+        with gamma-clip applied multiplicatively on the per-neuron prefactor.
+        """
+        learning_rate = args["get_learning_rate"](t, state, args)
+        RPE = args.get("RPE", jnp.array(0.0))
+
+        # zeta_ij — the per-synapse OU excursion.
+        per_synapse_noise = args.get(
+            "per_synapse_excitatory_noise", jnp.zeros_like(state.G)
+        )
+        # Normalise by the OU diffusion strength so the update scale is
+        # invariant to the absolute noise level (matches the analogous
+        # normalisation in EligibilityLIFNetwork.compute_feature_drift).
+        per_synapse_noise_std = args.get("per_synapse_noise_std", 0.0)
+        relative_noise = jnp.where(
+            per_synapse_noise_std != 0.0,
+            per_synapse_noise / per_synapse_noise_std,
+            0.0,
+        )
+
+        # s_ij — synaptic activity (G / w0).
+        s_ij = state.G / self.synaptic_increment
+
+        # Voltage gate (per-neuron). When disabled, gate is identically 1.
+        delta_V = args.get("delta_V", self.delta_V)
+        if self.use_gating:
+            gate = self.gating_function(state.V, delta_V)
+        else:
+            gate = jnp.ones_like(state.V)
+
+        # MANDATORY gamma-clip (theorist Q5): bound the per-neuron prefactor
+        # |eta * delta_r * gate| <= update_clip. The clip is non-symmetric in
+        # the sense that it only scales |gate| down; never up.
+        prefactor_mag = jnp.abs(learning_rate * RPE * gate)
+        clip_factor = jnp.minimum(
+            jnp.array(1.0),
+            self.update_clip / (prefactor_mag + 1e-30),
+        )
+        gate_clipped = gate * clip_factor  # shape (N,)
+
+        # Multiplicative-on-weight OUA update.
+        # dW shape: (N, N + N_in)
+        dW = (
+            learning_rate
+            * RPE
+            * relative_noise
+            * s_ij
+            * gate_clipped[:, None]
+        )
+
+        # No update for non-existing connections.
+        dW = jnp.where(jnp.isnan(state.W), 0.0, dW)
+        return dW

--- a/src/adaptive_SNN/models/networks/oua_eligibility_LIF.py
+++ b/src/adaptive_SNN/models/networks/oua_eligibility_LIF.py
@@ -1,0 +1,98 @@
+"""Per-synapse eligibility-trace consolidation rule.
+
+Sibling of GatedLIFNetwork that consumes per-synapse OU noise (alpha = 1)
+instead of broadcasting per-neuron OU noise. Implements the (alpha=1, gate-on,
+eligibility) co-headline cell of unified §4.3.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.random as jr
+from jax import numpy as jnp
+
+from adaptive_SNN.models.networks._gating import voltage_gate
+from adaptive_SNN.models.networks.base import AbstractLIFNetwork
+from adaptive_SNN.models.networks.eligibility_LIF import ElibilityState, Eligibility
+from adaptive_SNN.utils.operators import DefaultIfNone, ElementWiseMul
+
+
+class PerSynapseGatedEligibilityLIFNetwork(AbstractLIFNetwork):
+    """Eligibility-trace consolidation with per-synapse OU noise + voltage gate.
+
+    Identical to GatedLIFNetwork except the eligibility drift reads the
+    per-synapse noise field args["per_synapse_excitatory_noise"] directly,
+    rather than broadcasting per-neuron noise across synapses.
+    """
+
+    tau_eligibility: float = 0.1
+    delta_V: float = 1.0e-3
+
+    def __init__(
+        self,
+        dt,
+        N_neurons: int,
+        N_inputs: int = 0,
+        tau_eligibility: float = 0.1,
+        delta_V: float = 1.0e-3,
+        key: jr.PRNGKey = jr.PRNGKey(0),
+        **parent_kwargs,
+    ):
+        super().__init__(dt=dt, N_neurons=N_neurons, N_inputs=N_inputs, key=key, **parent_kwargs)
+        self.tau_eligibility = tau_eligibility
+        self.delta_V = delta_V
+
+    def init_features(self) -> Eligibility:
+        return Eligibility(
+            eligibility=jnp.zeros((self.N_neurons, self.N_neurons + self.N_inputs))
+        )
+
+    def compute_feature_diffusion(self, t, state: ElibilityState, args):
+        return jax.tree.map(
+            lambda arr: DefaultIfNone(
+                default=jnp.zeros_like(arr),
+                else_do=ElementWiseMul(jnp.zeros_like(arr, dtype=arr.dtype)),
+            ),
+            state.features,
+        )
+
+    def compute_feature_drift(self, t, state: ElibilityState, args) -> Eligibility:
+        per_synapse_noise = args.get(
+            "per_synapse_excitatory_noise", jnp.zeros_like(state.G)
+        )
+        per_synapse_noise_std = args.get("per_synapse_noise_std", 0.0)
+        relative_noise = jnp.where(
+            per_synapse_noise_std != 0.0,
+            per_synapse_noise / per_synapse_noise_std,
+            0.0,
+        )
+        delta_V = args.get("delta_V", self.delta_V)
+        synaptic_traces = state.G
+        gate = self.gating_function(state.V, delta_V)[:, None]
+        d_eligibility = (
+            -state.features.eligibility / self.tau_eligibility
+            + relative_noise * synaptic_traces / self.synaptic_increment * gate
+        )
+        return Eligibility(eligibility=d_eligibility)
+
+    def compute_feature_update(self, t, state: ElibilityState, args) -> Eligibility:
+        return state.features
+
+    def noise_shape_features(self) -> Eligibility:
+        return Eligibility(eligibility=None)
+
+    def gating_function(self, voltage, delta_V):
+        return voltage_gate(
+            voltage,
+            delta_V,
+            reversal_potential_E=self.reversal_potential_E,
+            firing_threshold=self.firing_threshold,
+            resting_potential=self.resting_potential,
+        )
+
+    def compute_weight_updates(self, t, state: ElibilityState, args):
+        learning_rate = args["get_learning_rate"](t, state, args)
+        RPE = args.get("RPE", jnp.array(0.0))
+        dW = learning_rate * RPE * state.features.eligibility
+        dW = jnp.where(jnp.isnan(state.W), 0.0, dW)
+        return dW

--- a/src/adaptive_SNN/models/networks/per_synapse_noisy_network.py
+++ b/src/adaptive_SNN/models/networks/per_synapse_noisy_network.py
@@ -1,10 +1,16 @@
-"""Per-synapse noisy network wrapper.
+"""Per-synapse noisy network wrappers.
 
-Routes a 2D per-synapse OU noise process into args["per_synapse_excitatory_noise"]
-so that the multiplicative-on-weight injection in
-`AbstractLIFNetwork.compute_voltage_update` sees it. This is structurally the
-same as `NoisyNetwork` except the noise state has shape
-(N_neurons, N_neurons + N_inputs) rather than (N_neurons,).
+Two wrappers in this module:
+
+- `PerSynapseNoisyNetwork`: 2D per-synapse OU state routed into
+  args["per_synapse_excitatory_noise"]. The (alpha=1) endpoint of unified
+  Eq. 2.4.
+
+- `BroadcastingNoisyNetwork`: per-neuron 1D OU state broadcast across
+  excitatory synapses, equivalent to the (alpha=0) endpoint of unified
+  Eq. 2.4. Used to pair the per-neuron variants (A-PN, B-PN) with their
+  per-synapse twins (A-PS, B-PS) under a shared OUA / eligibility update
+  interface that reads args["per_synapse_excitatory_noise"].
 """
 
 from __future__ import annotations
@@ -16,6 +22,7 @@ import jax.numpy as jnp
 from jaxtyping import Array
 
 from adaptive_SNN.models.networks.base import LIFState, NeuronModelABC
+from adaptive_SNN.models.networks.noisy_network import NoisyNetworkState
 from adaptive_SNN.models.noise.base import NoiseModelABC
 from adaptive_SNN.utils.operators import MixedPyTreeOperator
 
@@ -126,11 +133,155 @@ class PerSynapseNoisyNetwork(NeuronModelABC):
         constructor value is used.
 
         `use_noise` is honoured: when False, the effective std is 0 (no noise).
+
+        Returned shape matches the 2D noise state (N_neurons, N_neurons + N_inputs)
+        for clean broadcast against per_synapse_excitatory_noise downstream.
         """
         target_std = args.get(
             "per_synapse_noise_std_target", self.noise_model.noise_std
         )
         use_noise = args.get("use_noise", jnp.array(True))
-        # Scalar or 1D (per neuron) is acceptable; keep as-is.
-        effective_std = jnp.where(use_noise, target_std, 0.0)
-        return effective_std
+        effective_scalar = jnp.where(use_noise, target_std, 0.0)
+        # Broadcast to 2D state shape.
+        N = self.base_network.N_neurons
+        N_in = self.base_network.N_inputs
+        effective_scalar = jnp.broadcast_to(
+            jnp.atleast_1d(effective_scalar), (N,)
+        )
+        return jnp.broadcast_to(effective_scalar[:, None], (N, N + N_in)).astype(default_float)
+
+
+class BroadcastingNoisyNetwork(NeuronModelABC):
+    """Per-neuron OU noise broadcast across excitatory synapses.
+
+    Routes the per-neuron OU noise state into
+    args["per_synapse_excitatory_noise"] as
+        zeta_ij = xi_i / |E_i| * mask_j
+    so that the sum over excitatory synapses recovers xi_i. This is the
+    alpha = 0 endpoint of unified Eq. 2.4 expressed in the per-synapse
+    routing slot, letting per-synapse-aware consolidation rules
+    (OUAMeanReversionLIFNetwork, PerSynapseGatedEligibilityLIFNetwork) be
+    used at the per-neuron geometry with shared code.
+
+    The per-synapse noise std is set to (sigma_xi / |E_i|) to match: the
+    relative noise xi_i / sigma_xi is preserved per excitatory synapse.
+
+    `|E_i|` (number of existing excitatory synapses per neuron) is computed
+    from the initial weight matrix at construction time and is treated as
+    a constant during the simulation.
+    """
+
+    base_network: NeuronModelABC
+    noise_model: NoiseModelABC
+    excitatory_count_per_neuron: Array  # shape (N_neurons,)
+    min_noise_std: float = 5e-9
+
+    def __init__(
+        self,
+        neuron_model: NeuronModelABC,
+        noise_model: NoiseModelABC,
+        min_noise_std: float | None = None,
+    ):
+        self.base_network = neuron_model
+        self.noise_model = noise_model
+        if min_noise_std is not None:
+            self.min_noise_std = min_noise_std
+        # Count existing excitatory synapses per postsynaptic neuron from the
+        # initial weight matrix.
+        W0 = neuron_model.initial.W
+        exc_mask = neuron_model.excitatory_mask
+        existing = ~jnp.isnan(W0) & exc_mask[None, :]
+        count = jnp.sum(existing, axis=1).astype(default_float)
+        # Avoid division by zero: replace 0 with 1 (those neurons have no E
+        # input so the noise has nothing to broadcast onto anyway).
+        self.excitatory_count_per_neuron = jnp.where(count > 0, count, 1.0)
+
+    @property
+    def initial(self):
+        return NoisyNetworkState(self.base_network.initial, self.noise_model.initial)
+
+    def _broadcast(self, noise_state, noise_std):
+        """Build (N, N+N_in) per-synapse noise from per-neuron OU state.
+
+        The per-neuron noise xi_i has units of conductance (nS) and is added
+        to the aggregate E conductance in NoisyNetwork's path. For broadcast
+        through the multiplicative-on-weight per-synapse path it must be
+        converted to W (dimensionless) units: divide by synaptic_increment.
+        The broadcast also divides by |E_i| so the aggregate contribution
+        sum_j (xi_i/(|E_i|*w0)) * G_ij = (xi_i / w0) * <G>_active ~ xi_i in nS.
+        """
+        exc_mask = self.base_network.excitatory_mask.astype(default_float)
+        w0 = self.base_network.synaptic_increment
+        per_neuron_scaled = noise_state / (self.excitatory_count_per_neuron * w0)
+        per_syn_noise = per_neuron_scaled[:, None] * exc_mask[None, :]
+        std_1d = jnp.broadcast_to(
+            noise_std / (self.excitatory_count_per_neuron * w0),
+            (self.base_network.N_neurons,),
+        )
+        per_syn_std = jnp.broadcast_to(
+            std_1d[:, None], per_syn_noise.shape
+        ).astype(default_float)
+        return per_syn_noise, per_syn_std
+
+    def drift(self, t, state: NoisyNetworkState, args: dict):
+        network_state, noise_state = state.network_state, state.noise_state
+
+        # Compute the per-neuron OU diffusion strength (matches Alexander's
+        # NoisyNetwork.compute_desired_noise_std for back-compat with the per-
+        # neuron OUP diffusion).
+        per_neuron_std = self.compute_desired_noise_std(t, state, args)
+
+        # Broadcast into per-synapse routing slot ONLY. We do NOT also set
+        # excitatory_noise: that would double-count noise into the per-neuron
+        # additive injection AND the per-synapse multiplicative injection.
+        per_syn_noise, per_syn_std = self._broadcast(noise_state, per_neuron_std)
+        args.update(
+            {
+                # noise_std exposed so the per-neuron OUP diffusion sees the
+                # activity-dependent std (NeuralNoiseOUP reads "noise_std").
+                "noise_std": per_neuron_std,
+                "per_synapse_excitatory_noise": per_syn_noise,
+                "per_synapse_noise_std": per_syn_std,
+            }
+        )
+
+        network_drift = self.base_network.drift(t, network_state, args)
+        noise_drift = self.noise_model.drift(t, noise_state, args)
+        return NoisyNetworkState(network_drift, noise_drift)
+
+    def diffusion(self, t, state: NoisyNetworkState, args: dict):
+        network_state, noise_state = state.network_state, state.noise_state
+        network_diffusion = self.base_network.diffusion(t, network_state, args)
+        noise_diffusion = self.noise_model.diffusion(t, noise_state, args)
+        return MixedPyTreeOperator(
+            NoisyNetworkState(network_diffusion, noise_diffusion)
+        )
+
+    @property
+    def noise_shape(self):
+        return NoisyNetworkState(
+            self.base_network.noise_shape, self.noise_model.noise_shape
+        )
+
+    def terms(self, key):
+        process_noise = dfx.UnsafeBrownianPath(
+            shape=self.noise_shape, key=key, levy_area=dfx.SpaceTimeLevyArea
+        )
+        return dfx.MultiTerm(
+            dfx.ODETerm(self.drift), dfx.ControlTerm(self.diffusion, process_noise)
+        )
+
+    def update(self, t, state: NoisyNetworkState, args):
+        new_network_state = self.base_network.update(t, state.network_state, args)
+        return NoisyNetworkState(new_network_state, state.noise_state)
+
+    def compute_desired_noise_std(self, t, state: NoisyNetworkState, args):
+        synaptic_variance = state.network_state.var_E_conductance
+        use_noise = args.get(
+            "use_noise", jnp.array([False] * self.base_network.N_neurons)
+        )
+        noise_scale_hyperparam = args.get("noise_scale_hyperparam", 0.0)
+        desired_noise_std = jnp.sqrt(synaptic_variance) * noise_scale_hyperparam
+        desired_noise_std = self.min_noise_std + desired_noise_std
+        desired_noise_std = jnp.where(use_noise, desired_noise_std, 0.0)
+        return desired_noise_std

--- a/src/adaptive_SNN/models/networks/per_synapse_noisy_network.py
+++ b/src/adaptive_SNN/models/networks/per_synapse_noisy_network.py
@@ -1,0 +1,136 @@
+"""Per-synapse noisy network wrapper.
+
+Routes a 2D per-synapse OU noise process into args["per_synapse_excitatory_noise"]
+so that the multiplicative-on-weight injection in
+`AbstractLIFNetwork.compute_voltage_update` sees it. This is structurally the
+same as `NoisyNetwork` except the noise state has shape
+(N_neurons, N_neurons + N_inputs) rather than (N_neurons,).
+"""
+
+from __future__ import annotations
+
+import diffrax as dfx
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array
+
+from adaptive_SNN.models.networks.base import LIFState, NeuronModelABC
+from adaptive_SNN.models.noise.base import NoiseModelABC
+from adaptive_SNN.utils.operators import MixedPyTreeOperator
+
+default_float = jnp.float64 if jax.config.jax_enable_x64 else jnp.float32
+
+
+class PerSynapseNoisyNetworkState(eqx.Module):
+    """State container for PerSynapseNoisyNetwork.
+
+    The `noise_state` is 2D, one OU process per synapse.
+    """
+
+    network_state: LIFState
+    noise_state: Array  # shape (N_neurons, N_neurons + N_inputs)
+
+
+class PerSynapseNoisyNetwork(NeuronModelABC):
+    """Compose a base LIF network with per-synapse OU noise.
+
+    The base network's compute_voltage_update reads
+    args["per_synapse_excitatory_noise"] and applies it multiplicatively on the
+    per-synapse weight before multiplying by the synaptic activity G:
+        effective_W_ij = (W_ij + zeta_ij)
+        weighted_conductance_ij = effective_W_ij * G_ij
+    This is the multiplicative-on-weight convention (unified §2.1, Eq. 2.1a).
+
+    The `per_synapse_noise_std` is the per-synapse OU diffusion strength used
+    to normalise weight updates inside the consolidation rule (analogue of
+    NoisyNetwork.compute_desired_noise_std for per-neuron noise). For
+    overnight r1 we use a *frozen* scalar set externally (after the variance-
+    match calibration); online adaptation is a follow-up.
+    """
+
+    base_network: NeuronModelABC
+    noise_model: NoiseModelABC
+    min_noise_std: float = 5e-9
+
+    def __init__(
+        self,
+        neuron_model: NeuronModelABC,
+        noise_model: NoiseModelABC,
+        min_noise_std: float | None = None,
+    ):
+        self.base_network = neuron_model
+        self.noise_model = noise_model
+        if min_noise_std is not None:
+            self.min_noise_std = min_noise_std
+
+    @property
+    def initial(self):
+        return PerSynapseNoisyNetworkState(
+            self.base_network.initial, self.noise_model.initial
+        )
+
+    def drift(self, t, state: PerSynapseNoisyNetworkState, args: dict):
+        network_state, noise_state = state.network_state, state.noise_state
+
+        # Compute the desired per-synapse noise scale (for r1, a scalar passed
+        # in via args; defaults to the noise_model's constructor noise_std).
+        per_synapse_noise_std = self.compute_desired_noise_std(t, state, args)
+
+        # Inject the noise so the base network's compute_voltage_update and the
+        # consolidation rule can both reach it.
+        args.update(
+            {
+                "per_synapse_excitatory_noise": noise_state,
+                "per_synapse_noise_std": per_synapse_noise_std,
+            }
+        )
+
+        network_drift = self.base_network.drift(t, network_state, args)
+        noise_drift = self.noise_model.drift(t, noise_state, args)
+        return PerSynapseNoisyNetworkState(network_drift, noise_drift)
+
+    def diffusion(self, t, state: PerSynapseNoisyNetworkState, args: dict):
+        network_state, noise_state = state.network_state, state.noise_state
+        network_diffusion = self.base_network.diffusion(t, network_state, args)
+        noise_diffusion = self.noise_model.diffusion(t, noise_state, args)
+        return MixedPyTreeOperator(
+            PerSynapseNoisyNetworkState(network_diffusion, noise_diffusion)
+        )
+
+    @property
+    def noise_shape(self):
+        return PerSynapseNoisyNetworkState(
+            self.base_network.noise_shape,
+            self.noise_model.noise_shape,
+        )
+
+    def terms(self, key):
+        process_noise = dfx.UnsafeBrownianPath(
+            shape=self.noise_shape, key=key, levy_area=dfx.SpaceTimeLevyArea
+        )
+        return dfx.MultiTerm(
+            dfx.ODETerm(self.drift), dfx.ControlTerm(self.diffusion, process_noise)
+        )
+
+    def update(self, t, state: PerSynapseNoisyNetworkState, args):
+        new_network_state = self.base_network.update(t, state.network_state, args)
+        return PerSynapseNoisyNetworkState(new_network_state, state.noise_state)
+
+    def compute_desired_noise_std(self, t, state: PerSynapseNoisyNetworkState, args):
+        """Return the per-synapse OU diffusion strength.
+
+        For overnight r1, callers supply a pre-computed scalar via
+        args["per_synapse_noise_std_target"] (the calibrated sigma_E from
+        Eq. 2.6 of the unified model). If absent, the noise model's
+        constructor value is used.
+
+        `use_noise` is honoured: when False, the effective std is 0 (no noise).
+        """
+        target_std = args.get(
+            "per_synapse_noise_std_target", self.noise_model.noise_std
+        )
+        use_noise = args.get("use_noise", jnp.array(True))
+        # Scalar or 1D (per neuron) is acceptable; keep as-is.
+        effective_std = jnp.where(use_noise, target_std, 0.0)
+        return effective_std

--- a/src/adaptive_SNN/models/noise/__init__.py
+++ b/src/adaptive_SNN/models/noise/__init__.py
@@ -1,5 +1,6 @@
 # src/adaptive_SNN/models/noise/__init__.py
 from adaptive_SNN.models.noise.oup import OUP, NeuralNoiseOUP
+from adaptive_SNN.models.noise.per_synapse_oup import PerSynapseOUP
 from adaptive_SNN.models.noise.poisson_jump import PoissonJumpProcess
 
-__all__ = ["NeuralNoiseOUP", "OUP", "PoissonJumpProcess"]
+__all__ = ["NeuralNoiseOUP", "OUP", "PerSynapseOUP", "PoissonJumpProcess"]

--- a/src/adaptive_SNN/models/noise/per_synapse_oup.py
+++ b/src/adaptive_SNN/models/noise/per_synapse_oup.py
@@ -1,0 +1,121 @@
+"""Per-synapse Ornstein-Uhlenbeck noise process.
+
+The state is a 2D matrix of shape (N_neurons, N_neurons + N_inputs) carrying
+one independent OU process per (postsynaptic, presynaptic) pair. Diffusion is
+restricted to excitatory synapses via the `excitatory_mask`. Drift is
+element-wise -(x - mean)/tau.
+
+This is the per-synapse endpoint (alpha = 1) of the exploration-geometry
+family in [[unified-model-and-merger-plan-20260518]] Eq. 2.1b. The companion
+per-neuron OU process is `OUP` / `NeuralNoiseOUP` in the same package.
+"""
+
+from __future__ import annotations
+
+import diffrax as dfx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array
+
+from adaptive_SNN.models.noise.base import NoiseModelABC
+from adaptive_SNN.utils.operators import ElementWiseMul
+
+default_float = jnp.float64 if jax.config.jax_enable_x64 else jnp.float32
+
+
+class PerSynapseOUP(NoiseModelABC):
+    """Per-synapse Ornstein-Uhlenbeck noise.
+
+    State shape: (N_neurons, N_neurons + N_inputs).
+    Drift: -(x - mean) / tau
+    Diffusion: element-wise diagonal, scaled by sqrt(2/tau) * noise_std *
+               excitatory_mask[None, :]. Inhibitory synapses receive zero
+               diffusion (they stay at the mean throughout).
+
+    The Wiener path has shape (N_neurons, N_neurons + N_inputs) with
+    independent increments per (i, j).
+
+    Stationary marginal variance per excitatory synapse: noise_std^2 * tau / 2.
+    """
+
+    tau: float | Array = 6e-3
+    noise_std: float | Array = 0.0
+    mean: float | Array = 0.0
+    N_neurons: int = 1
+    N_inputs: int = 0
+    excitatory_mask: Array = None  # type: ignore[assignment]
+
+    def __init__(
+        self,
+        N_neurons: int,
+        N_inputs: int,
+        excitatory_mask: Array,
+        tau: float | Array = 6e-3,
+        noise_std: float | Array = 0.0,
+        mean: float | Array = 0.0,
+    ):
+        if excitatory_mask.shape != (N_neurons + N_inputs,):
+            raise ValueError(
+                f"excitatory_mask must have shape ({N_neurons + N_inputs},), "
+                f"got {excitatory_mask.shape}"
+            )
+        self.N_neurons = N_neurons
+        self.N_inputs = N_inputs
+        self.excitatory_mask = excitatory_mask.astype(default_float)
+        self.tau = tau
+        self.noise_std = noise_std
+        self.mean = mean
+
+    @property
+    def initial(self):
+        return jnp.full(
+            (self.N_neurons, self.N_neurons + self.N_inputs),
+            self.mean,
+            dtype=default_float,
+        )
+
+    def drift(self, t, x, args):
+        return -1.0 / self.tau * (x - self.mean)
+
+    def diffusion(self, t, x, args):
+        # The args value takes precedence (state-dependent calibration via
+        # PerSynapseNoisyNetwork.compute_desired_noise_std). Falls back to
+        # the constructor-level noise_std.
+        noise_std = (
+            self.noise_std
+            if args is None
+            else args.get("per_synapse_noise_std", self.noise_std)
+        )
+
+        # Excitatory mask broadcast across postsynaptic neurons (rows).
+        # Result shape: (N_neurons, N_neurons + N_inputs).
+        scale = (
+            jnp.sqrt(2.0 / self.tau)
+            * noise_std
+            * self.excitatory_mask[None, :].astype(default_float)
+        )
+        # Broadcast to full state shape if scalar/1D input.
+        scale = jnp.broadcast_to(
+            scale, (self.N_neurons, self.N_neurons + self.N_inputs)
+        ).astype(default_float)
+        return ElementWiseMul(scale)
+
+    def update(self, t, x, args):
+        # Ensure inhibitory synapses remain pinned at the mean (defensive;
+        # diffusion is zero there but drift retains them at mean already).
+        return x
+
+    @property
+    def noise_shape(self):
+        return jax.ShapeDtypeStruct(
+            shape=(self.N_neurons, self.N_neurons + self.N_inputs),
+            dtype=default_float,
+        )
+
+    def terms(self, key):
+        process_noise = dfx.UnsafeBrownianPath(
+            shape=self.noise_shape, key=key, levy_area=dfx.SpaceTimeLevyArea
+        )
+        return dfx.MultiTerm(
+            dfx.ODETerm(self.drift), dfx.ControlTerm(self.diffusion, process_noise)
+        )

--- a/tests/test_oua_mean_reversion.py
+++ b/tests/test_oua_mean_reversion.py
@@ -1,0 +1,322 @@
+"""Unit tests for OUAMeanReversionLIFNetwork (P2).
+
+Covers:
+- no noise -> no update
+- no RPE -> no update
+- positive RPE + positive noise + active synapse -> positive dW
+- gating extremes (V -> E_E gives gate -> 0)
+- mandatory gamma-clip engages when prefactor would blow up
+- existing weight clipping (W >= 0) preserved
+- no update for non-existent connections
+- gate-off variant works
+- 1-neuron 1-synapse positive-RPE integration sanity (G2)
+"""
+
+from __future__ import annotations
+
+import diffrax as dfx
+import equinox as eqx
+import jax
+
+jax.config.update("jax_enable_x64", True)  # noqa: E402
+
+import jax.numpy as jnp  # noqa: E402
+import jax.random as jr  # noqa: E402
+
+from adaptive_SNN.models.networks.base import LIFState  # noqa: E402
+from adaptive_SNN.models.networks.oua_LIF import OUAMeanReversionLIFNetwork  # noqa: E402
+from adaptive_SNN.models.networks.per_synapse_noisy_network import (  # noqa: E402
+    PerSynapseNoisyNetwork,
+    PerSynapseNoisyNetworkState,
+)
+from adaptive_SNN.models.noise.per_synapse_oup import PerSynapseOUP  # noqa: E402
+
+
+def _make_args(N, N_in, **overrides):
+    args = {
+        "RPE": jnp.array(0.0),
+        "get_input_spikes": lambda t, s, a: jnp.zeros((N, N_in)),
+        "get_learning_rate": lambda t, s, a: jnp.array(1.0),
+        "get_desired_balance": lambda t, s, a: 0.0,
+        "use_noise": jnp.array(True),
+        "per_synapse_excitatory_noise": jnp.zeros((N, N + N_in)),
+        "per_synapse_noise_std": 1.0,
+    }
+    args.update(overrides)
+    return args
+
+
+def _make_state(net, W=None, G=None, V=None):
+    state = net.initial
+    if W is None:
+        W = jnp.full(state.W.shape, jnp.nan)
+        W = W.at[0, 0].set(1.0) if state.W.shape[1] > 0 else W
+    if G is None:
+        G = jnp.zeros(state.G.shape)
+    if V is None:
+        V = jnp.full((net.N_neurons,), net.resting_potential)
+    return LIFState(
+        V=V,
+        S=state.S,
+        W=W,
+        G=G,
+        firing_rate=state.firing_rate,
+        mean_E_conductance=state.mean_E_conductance,
+        var_E_conductance=state.var_E_conductance,
+        time_since_last_spike=state.time_since_last_spike,
+        spike_buffer=state.spike_buffer,
+        buffer_index=state.buffer_index,
+        features=state.features,
+    )
+
+
+def test_no_noise_no_update():
+    N, N_in = 2, 1
+    net = OUAMeanReversionLIFNetwork(
+        N_neurons=N, N_inputs=N_in, dt=1e-4, key=jr.PRNGKey(0)
+    )
+    state = _make_state(net, G=jnp.ones_like(net.initial.G))
+    args = _make_args(N, N_in, RPE=jnp.array(1.0))  # no per_synapse_noise (default 0)
+    dW = net.compute_weight_updates(0.0, state, args)
+    assert jnp.all(jnp.where(jnp.isnan(dW), 0.0, dW) == 0.0)
+
+
+def test_no_rpe_no_update():
+    N, N_in = 2, 1
+    net = OUAMeanReversionLIFNetwork(
+        N_neurons=N, N_inputs=N_in, dt=1e-4, key=jr.PRNGKey(0)
+    )
+    state = _make_state(net, G=jnp.ones_like(net.initial.G))
+    args = _make_args(
+        N,
+        N_in,
+        RPE=jnp.array(0.0),
+        per_synapse_excitatory_noise=jnp.ones((N, N + N_in)) * 1e-9,
+    )
+    dW = net.compute_weight_updates(0.0, state, args)
+    assert jnp.all(jnp.where(jnp.isnan(dW), 0.0, dW) == 0.0)
+
+
+def test_positive_rpe_positive_correlation():
+    """Constant positive RPE + positive noise + active synapse + gating-active V -> dW > 0."""
+    N, N_in = 1, 1
+    net = OUAMeanReversionLIFNetwork(
+        N_neurons=N,
+        N_inputs=N_in,
+        dt=1e-4,
+        key=jr.PRNGKey(0),
+        initial_input_weight=1.0,
+        delta_V=1e-3,
+        use_gating=True,
+        update_clip=10.0,  # generous so clip is inactive in this regime
+    )
+    # Place V in a gate-active region (just below threshold).
+    V = jnp.array([-55e-3])
+    # Force the input synapse onto neuron 0 to be excitatory and active
+    object.__setattr__(net, "excitatory_mask", jnp.array([False, True]))
+    object.__setattr__(
+        net, "synaptic_time_constants", jnp.where(net.excitatory_mask, net.tau_E, net.tau_I)
+    )
+    W = jnp.full((N, N + N_in), jnp.nan).at[0, 1].set(1.0)
+    G = jnp.zeros((N, N + N_in)).at[0, 1].set(1.0)
+    state = _make_state(net, W=W, G=G, V=V)
+    ps_noise = jnp.zeros((N, N + N_in)).at[0, 1].set(2e-9)
+    args = _make_args(
+        N,
+        N_in,
+        RPE=jnp.array(0.5),
+        per_synapse_excitatory_noise=ps_noise,
+        per_synapse_noise_std=1e-9,
+        get_learning_rate=lambda t, s, a: jnp.array(0.01),
+    )
+    dW = net.compute_weight_updates(0.0, state, args)
+    # The active excitatory synapse [0, 1] should receive a positive update.
+    assert dW[0, 1] > 0.0
+    # Non-existing connection [0, 0] (NaN W) must receive zero update.
+    assert dW[0, 0] == 0.0
+
+
+def test_gating_zero_at_E_E():
+    N, N_in = 2, 0
+    net = OUAMeanReversionLIFNetwork(
+        N_neurons=N, N_inputs=N_in, dt=1e-4, key=jr.PRNGKey(0), delta_V=1e-3
+    )
+    V = jnp.array([0.0, -70e-3])  # neuron 0 at E_E, neuron 1 at rest
+    gate = net.gating_function(V, net.delta_V)
+    # At E_E, driving force is 0 so gate -> 0
+    assert jnp.abs(gate[0]) < 1e-10
+    # Well below threshold, the exponential is also small but nonzero;
+    # the gate is finite. We only check the E_E zero crossing strictly.
+
+
+def test_gating_clip_engages_in_surrogate_spike_regime():
+    """With V driven above threshold and small delta_V, prefactor blows up but is clipped."""
+    N, N_in = 1, 1
+    delta_V = 1e-5  # very small -> gate spikes
+    update_clip = 0.1
+    net = OUAMeanReversionLIFNetwork(
+        N_neurons=N,
+        N_inputs=N_in,
+        dt=1e-4,
+        key=jr.PRNGKey(0),
+        delta_V=delta_V,
+        use_gating=True,
+        update_clip=update_clip,
+    )
+    object.__setattr__(net, "excitatory_mask", jnp.array([False, True]))
+    object.__setattr__(
+        net, "synaptic_time_constants", jnp.where(net.excitatory_mask, net.tau_E, net.tau_I)
+    )
+    # Place V above threshold to push the gate's exp into the runaway regime.
+    V = jnp.array([-45e-3])
+    W = jnp.full((N, N + N_in), jnp.nan).at[0, 1].set(1.0)
+    # G = synaptic_increment so that s_ij = G / w0 = 1 (O(1) for clean bounds)
+    G = jnp.zeros((N, N + N_in)).at[0, 1].set(net.synaptic_increment)
+    state = _make_state(net, W=W, G=G, V=V)
+    ps_noise = jnp.zeros((N, N + N_in)).at[0, 1].set(5e-9)
+    args = _make_args(
+        N,
+        N_in,
+        RPE=jnp.array(1.0),
+        per_synapse_excitatory_noise=ps_noise,
+        per_synapse_noise_std=1e-9,
+        get_learning_rate=lambda t, s, a: jnp.array(1.0),
+    )
+    dW = net.compute_weight_updates(0.0, state, args)
+    # Unclipped gate at V=-45mV, delta_V=1e-5 is astronomical (~ 1e220).
+    # After clip, |lr*RPE*gate_clipped| <= update_clip = 0.1; with
+    # |relative_noise|=5, |s_ij|=1, the bound on |dW| is 0.1*5*1 = 0.5.
+    assert jnp.isfinite(dW[0, 1]), f"dW must be finite, got {dW[0, 1]}"
+    assert jnp.abs(dW[0, 1]) <= update_clip * 5.0 * 1.0 + 1e-9, (
+        f"|dW|={jnp.abs(dW[0, 1])} > {update_clip * 5.0}"
+    )
+    # And the clip must actually have engaged: without it, |dW| would be ~ 1e220.
+    # Check that the result is at least within a factor of 100 of the bound
+    # (not vanishingly small either).
+    assert jnp.abs(dW[0, 1]) > update_clip * 5.0 / 100.0
+
+
+def test_gate_off_variant():
+    """use_gating=False -> gate is identically 1, clip still applies on |lr*RPE|."""
+    N, N_in = 1, 1
+    net = OUAMeanReversionLIFNetwork(
+        N_neurons=N,
+        N_inputs=N_in,
+        dt=1e-4,
+        key=jr.PRNGKey(0),
+        use_gating=False,
+        update_clip=10.0,
+    )
+    object.__setattr__(net, "excitatory_mask", jnp.array([False, True]))
+    object.__setattr__(
+        net, "synaptic_time_constants", jnp.where(net.excitatory_mask, net.tau_E, net.tau_I)
+    )
+    V = jnp.array([-55e-3])
+    W = jnp.full((N, N + N_in), jnp.nan).at[0, 1].set(1.0)
+    # G = synaptic_increment * 3 so s_ij = 3 (clean integer multiplier)
+    G = jnp.zeros((N, N + N_in)).at[0, 1].set(3.0 * net.synaptic_increment)
+    state = _make_state(net, W=W, G=G, V=V)
+    ps_noise = jnp.zeros((N, N + N_in)).at[0, 1].set(2e-9)
+    args = _make_args(
+        N,
+        N_in,
+        RPE=jnp.array(0.5),
+        per_synapse_excitatory_noise=ps_noise,
+        per_synapse_noise_std=1e-9,
+        get_learning_rate=lambda t, s, a: jnp.array(0.01),
+    )
+    dW = net.compute_weight_updates(0.0, state, args)
+    # Gate = 1 -> dW = lr * RPE * relative_noise * s_ij = 0.01 * 0.5 * 2 * 3 = 0.03
+    expected = 0.01 * 0.5 * 2.0 * 3.0
+    assert jnp.isclose(dW[0, 1], expected, atol=1e-12)
+
+
+def test_no_update_for_nonexistent_connections():
+    N, N_in = 2, 1
+    net = OUAMeanReversionLIFNetwork(
+        N_neurons=N, N_inputs=N_in, dt=1e-4, key=jr.PRNGKey(0)
+    )
+    W = jnp.full((N, N + N_in), jnp.nan)  # no connections at all
+    G = jnp.ones((N, N + N_in))
+    state = _make_state(net, W=W, G=G)
+    ps_noise = jnp.ones((N, N + N_in)) * 1e-9
+    args = _make_args(
+        N,
+        N_in,
+        RPE=jnp.array(1.0),
+        per_synapse_excitatory_noise=ps_noise,
+        per_synapse_noise_std=1e-9,
+        get_learning_rate=lambda t, s, a: jnp.array(0.01),
+    )
+    dW = net.compute_weight_updates(0.0, state, args)
+    assert jnp.all(dW == 0.0)
+
+
+def test_weight_clipping_preserved():
+    """OUAMeanReversionLIFNetwork still enforces W >= 0 via inherited clip_weights."""
+    N, N_in = 1, 1
+    net = OUAMeanReversionLIFNetwork(
+        N_neurons=N, N_inputs=N_in, dt=1e-4, key=jr.PRNGKey(0)
+    )
+    W = jnp.full((N, N + N_in), jnp.nan)
+    W = W.at[0, 0].set(-3.0)  # negative existing weight
+    state = _make_state(net, W=W)
+    state = net.clip_weights(0.0, state, {})
+    assert state.W[0, 0] == 0.0
+
+
+def test_integration_single_synapse_weight_increases():
+    """G2 sanity: 1 neuron, 1 learnable synapse, positive constant RPE, run > 0.5s -> W grows."""
+    N, N_in = 1, 1
+    dt = 1e-4
+    delta_V = 1e-3
+    net = OUAMeanReversionLIFNetwork(
+        N_neurons=N,
+        N_inputs=N_in,
+        dt=dt,
+        key=jr.PRNGKey(0),
+        initial_input_weight=0.5,
+        delta_V=delta_V,
+        use_gating=True,
+        update_clip=10.0,
+        fully_connected_input=True,
+    )
+    # Make the single input neuron excitatory and the recurrent neuron also excitatory.
+    object.__setattr__(net, "excitatory_mask", jnp.array([True, True]))
+    object.__setattr__(
+        net, "synaptic_time_constants", jnp.where(net.excitatory_mask, net.tau_E, net.tau_I)
+    )
+
+    mask = jnp.array([True, True])
+    oup = PerSynapseOUP(
+        N_neurons=N,
+        N_inputs=N_in,
+        excitatory_mask=mask,
+        tau=net.tau_E,
+        noise_std=1e-9,
+    )
+    netw = PerSynapseNoisyNetwork(net, oup)
+
+    # Sanity check: just verify compute_weight_updates returns the right sign over
+    # a hand-rolled forward step. We avoid the full diffrax integration here
+    # (it would require feeding spikes, RPE, etc.); the integration sanity
+    # comes from P3.
+    W = jnp.full((N, N + N_in), jnp.nan).at[0, 1].set(0.5)
+    G = jnp.zeros((N, N + N_in)).at[0, 1].set(1.0)
+    V = jnp.array([-55e-3])
+    inner_state = _make_state(net, W=W, G=G, V=V)
+    state = PerSynapseNoisyNetworkState(
+        inner_state, jnp.zeros((N, N + N_in)).at[0, 1].set(3e-9)
+    )
+    args = {
+        "RPE": jnp.array(0.8),
+        "get_input_spikes": lambda t, s, a: jnp.zeros((N, N_in)),
+        "get_learning_rate": lambda t, s, a: jnp.array(0.1),
+        "get_desired_balance": lambda t, s, a: 0.0,
+        "use_noise": jnp.array(True),
+        "per_synapse_noise_std_target": 1e-9,
+    }
+    drift = netw.drift(0.0, state, args)
+    dW = drift.network_state.W
+    # Accumulated over dt: ~ 0.1 * 0.8 * 3 * 1 * gate ~ positive non-zero
+    assert dW[0, 1] > 0.0

--- a/tests/test_per_synapse_oup.py
+++ b/tests/test_per_synapse_oup.py
@@ -1,0 +1,271 @@
+"""Unit tests for PerSynapseOUP + PerSynapseNoisyNetwork (P1).
+
+Covers:
+- initial state shape and dtype
+- drift = -(x - mean)/tau
+- diffusion zero on inhibitory synapses
+- stationary marginal variance ~= noise_std^2 * tau / 2 within tolerance
+- per-synapse noise routes into args via PerSynapseNoisyNetwork
+- multiplicative-on-weight injection in compute_voltage_update preserves the
+  existing per-neuron path when per-synapse noise is absent
+"""
+
+from __future__ import annotations
+
+import diffrax as dfx
+import jax
+
+jax.config.update("jax_enable_x64", True)  # noqa: E402
+
+import jax.numpy as jnp  # noqa: E402
+import jax.random as jr  # noqa: E402
+
+from adaptive_SNN.models.networks.base import LIFState  # noqa: E402
+from adaptive_SNN.models.networks.default_LIF import LIFNetwork  # noqa: E402
+from adaptive_SNN.models.networks.per_synapse_noisy_network import (  # noqa: E402
+    PerSynapseNoisyNetwork,
+    PerSynapseNoisyNetworkState,
+)
+from adaptive_SNN.models.noise.per_synapse_oup import PerSynapseOUP  # noqa: E402
+
+
+def _make_excitatory_mask(N_neurons: int, N_inputs: int, n_E_in: int) -> jnp.ndarray:
+    """Half recurrent excitatory + n_E_in excitatory inputs."""
+    n_E_rec = N_neurons // 2
+    return jnp.concatenate(
+        [
+            jnp.ones((n_E_rec,), dtype=bool),
+            jnp.zeros((N_neurons - n_E_rec,), dtype=bool),
+            jnp.ones((n_E_in,), dtype=bool),
+            jnp.zeros((N_inputs - n_E_in,), dtype=bool),
+        ]
+    )
+
+
+def test_initial_state_shape():
+    N, N_in, n_E_in = 4, 3, 2
+    mask = _make_excitatory_mask(N, N_in, n_E_in)
+    oup = PerSynapseOUP(
+        N_neurons=N, N_inputs=N_in, excitatory_mask=mask, tau=6e-3, noise_std=1e-9
+    )
+    s0 = oup.initial
+    assert s0.shape == (N, N + N_in)
+    assert jnp.all(s0 == 0.0)
+
+
+def test_drift_value():
+    N, N_in, n_E_in = 3, 2, 1
+    mask = _make_excitatory_mask(N, N_in, n_E_in)
+    oup = PerSynapseOUP(
+        N_neurons=N, N_inputs=N_in, excitatory_mask=mask, tau=6e-3, noise_std=1e-9
+    )
+    x = jr.normal(jr.PRNGKey(0), (N, N + N_in))
+    d = oup.drift(0.0, x, {})
+    expected = -x / 6e-3
+    assert jnp.allclose(d, expected, atol=1e-12)
+
+
+def test_diffusion_zero_on_inhibitory_synapses():
+    N, N_in, n_E_in = 4, 3, 2
+    mask = _make_excitatory_mask(N, N_in, n_E_in)
+    oup = PerSynapseOUP(
+        N_neurons=N, N_inputs=N_in, excitatory_mask=mask, tau=6e-3, noise_std=2e-9
+    )
+    op = oup.diffusion(0.0, oup.initial, {})
+    # mv with unit Wiener step returns scale element-wise
+    unit_dw = jnp.ones((N, N + N_in))
+    out = op.mv(unit_dw)
+    # Inhibitory columns (where mask is False) must be zero
+    inh_cols = ~mask
+    assert jnp.all(out[:, inh_cols] == 0.0)
+    # Excitatory columns must be sqrt(2/tau) * noise_std
+    expected_exc = jnp.sqrt(2.0 / 6e-3) * 2e-9
+    assert jnp.allclose(out[:, mask], expected_exc, atol=1e-15)
+
+
+def test_stationary_marginal_variance():
+    """Simulate the pure OU SDE for ~30 tau and check stationary variance."""
+    N, N_in, n_E_in = 2, 1, 1
+    mask = _make_excitatory_mask(N, N_in, n_E_in)
+    tau, sigma = 6e-3, 1.5e-9
+    oup = PerSynapseOUP(
+        N_neurons=N, N_inputs=N_in, excitatory_mask=mask, tau=tau, noise_std=sigma
+    )
+    # Use VirtualBrownianTree for deterministic check; simulate t in [0, 30 tau]
+    t0, t1 = 0.0, 30 * tau
+    key = jr.PRNGKey(7)
+    process_noise = dfx.VirtualBrownianTree(
+        t0, t1, shape=oup.noise_shape, key=key, levy_area=dfx.SpaceTimeLevyArea, tol=1e-5
+    )
+    terms = dfx.MultiTerm(
+        dfx.ODETerm(oup.drift), dfx.ControlTerm(oup.diffusion, process_noise)
+    )
+    # Save dense over the second half (after burn-in of >10 tau)
+    ts_save = jnp.linspace(15 * tau, t1, 600)
+    sol = dfx.diffeqsolve(
+        terms=terms,
+        solver=dfx.EulerHeun(),
+        t0=t0,
+        t1=t1,
+        dt0=tau / 50,
+        y0=oup.initial,
+        args={},
+        adjoint=dfx.ForwardMode(),
+        saveat=dfx.SaveAt(ts=ts_save),
+        max_steps=20000,
+    )
+    ys = sol.ys  # (T, N, N+N_in)
+    exc_cols = mask
+    samples = ys[:, :, exc_cols]
+    var_empirical = jnp.var(samples)
+    # SDE: dx = -(x/tau) dt + sigma * sqrt(2/tau) dW
+    # Stationary variance: (sigma^2 * 2/tau) / (2/tau) = sigma^2.
+    var_theory = sigma**2
+    # Allow 30% tolerance (finite sample + finite burn-in over modest # of taus).
+    assert jnp.abs(var_empirical - var_theory) / var_theory < 0.30, (
+        f"empirical var={var_empirical:.3e}, theory={var_theory:.3e}"
+    )
+    # Inhibitory must remain ~0
+    inh_samples = ys[:, :, ~exc_cols]
+    assert jnp.all(jnp.abs(inh_samples) < 1e-15)
+
+
+def test_per_synapse_noisy_network_routes_into_args():
+    """PerSynapseNoisyNetwork.drift must populate args['per_synapse_excitatory_noise']."""
+    N, N_in = 3, 2
+    dt = 0.1e-3
+    net = LIFNetwork(N_neurons=N, N_inputs=N_in, dt=dt, key=jr.PRNGKey(0))
+    mask = net.excitatory_mask
+    oup = PerSynapseOUP(
+        N_neurons=N, N_inputs=N_in, excitatory_mask=mask, tau=6e-3, noise_std=1e-9
+    )
+    netw = PerSynapseNoisyNetwork(net, oup)
+
+    captured = {}
+    base_drift = net.drift
+
+    def wrapped_drift(t, x, args):
+        captured["seen"] = args.get("per_synapse_excitatory_noise")
+        captured["std"] = args.get("per_synapse_noise_std")
+        return base_drift(t, x, args)
+
+    netw_patched = netw.__class__.__new__(netw.__class__)
+    object.__setattr__(netw_patched, "base_network", net)
+    object.__setattr__(netw_patched, "noise_model", oup)
+    object.__setattr__(netw_patched, "min_noise_std", netw.min_noise_std)
+    # Just sanity: monkey-patch the base drift via attribute setter is awkward
+    # in eqx; instead drive `netw.drift` and verify args inside `base_network.drift`
+    args = {
+        "get_input_spikes": lambda t, s, a: jnp.zeros((N, N_in)),
+        "get_learning_rate": lambda t, s, a: jnp.array([0.0]),
+        "RPE": jnp.array([0.0]),
+        "use_noise": jnp.array(True),
+        "per_synapse_noise_std_target": 1e-9,
+    }
+    # Inject a known per-synapse noise state and check that compute_voltage_update sees it.
+    fake_noise = jnp.ones((N, N + N_in)) * 5e-9 * mask.astype(jnp.float64)[None, :]
+    state = PerSynapseNoisyNetworkState(net.initial, fake_noise)
+
+    # Compute drift; we then poke compute_voltage_update again via base_network
+    # to verify the args contract.
+    args_copy = dict(args)
+    netw.drift(0.0, state, args_copy)
+    assert "per_synapse_excitatory_noise" in args_copy
+    assert args_copy["per_synapse_excitatory_noise"].shape == (N, N + N_in)
+    assert jnp.allclose(args_copy["per_synapse_excitatory_noise"], fake_noise)
+    assert "per_synapse_noise_std" in args_copy
+
+
+def test_compute_voltage_update_no_per_synapse_noise_matches_baseline():
+    """When per_synapse_excitatory_noise is absent, behaviour is unchanged."""
+    N, N_in = 5, 3
+    net = LIFNetwork(N_neurons=N, N_inputs=N_in, dt=0.1e-3, key=jr.PRNGKey(1))
+
+    # State with non-trivial W, G
+    state = net.initial
+    rng = jr.PRNGKey(2)
+    W = jnp.where(jnp.isnan(state.W), jnp.nan, 5e-9 * jr.uniform(rng, state.W.shape))
+    G_vals = jr.uniform(jr.split(rng)[1], state.G.shape) * 0.5
+    state = LIFState(
+        V=state.V,
+        S=state.S,
+        W=W,
+        G=G_vals,
+        firing_rate=state.firing_rate,
+        mean_E_conductance=state.mean_E_conductance,
+        var_E_conductance=state.var_E_conductance,
+        time_since_last_spike=state.time_since_last_spike,
+        spike_buffer=state.spike_buffer,
+        buffer_index=state.buffer_index,
+        features=state.features,
+    )
+
+    base_args = {
+        "excitatory_noise": jnp.zeros((N,)),
+        "RPE": jnp.array([0.0]),
+        "get_input_spikes": lambda t, s, a: jnp.zeros((N, N_in)),
+        "get_learning_rate": lambda t, s, a: jnp.array([0.0]),
+        "get_desired_balance": lambda t, s, a: 0.0,
+        "noise_scale_hyperparam": 0.0,
+        "use_noise": jnp.array([False] * N),
+    }
+    dV_baseline = net.compute_voltage_update(0.0, state, base_args)
+
+    # Same args plus explicit zero per-synapse noise
+    args2 = dict(base_args)
+    args2["per_synapse_excitatory_noise"] = jnp.zeros_like(W)
+    dV_with_zero_ps = net.compute_voltage_update(0.0, state, args2)
+    assert jnp.allclose(dV_baseline, dV_with_zero_ps, atol=1e-15)
+
+
+def test_multiplicative_on_weight_injection_effect():
+    """Nonzero per-synapse noise on an active synapse changes dV in the right direction."""
+    N, N_in = 2, 1
+    net = LIFNetwork(
+        N_neurons=N, N_inputs=N_in, dt=0.1e-3, key=jr.PRNGKey(3), fully_connected_input=True
+    )
+    state = net.initial
+    # Force excitatory mask: neuron 0 excitatory, neuron 1 inhibitory, input excitatory
+    mask = jnp.array([True, False, True])
+    object.__setattr__(net, "excitatory_mask", mask)
+    object.__setattr__(
+        net, "synaptic_time_constants", jnp.where(mask, net.tau_E, net.tau_I)
+    )
+
+    # Build a state where:
+    # - W has value 1e-9 for one specific excitatory synapse onto neuron 0 from input 0
+    # - G has positive value on that synapse (synapse is active)
+    W = jnp.full(state.W.shape, jnp.nan)
+    W = W.at[0, 2].set(1e-9)  # excitatory input → neuron 0
+    G = jnp.zeros(state.G.shape)
+    G = G.at[0, 2].set(1.0)  # active
+    state = LIFState(
+        V=jnp.full((N,), net.resting_potential),
+        S=state.S,
+        W=W,
+        G=G,
+        firing_rate=state.firing_rate,
+        mean_E_conductance=state.mean_E_conductance,
+        var_E_conductance=state.var_E_conductance,
+        time_since_last_spike=state.time_since_last_spike,
+        spike_buffer=state.spike_buffer,
+        buffer_index=state.buffer_index,
+        features=state.features,
+    )
+    args_no_noise = {
+        "excitatory_noise": jnp.zeros((N,)),
+        "use_noise": jnp.array([False] * N),
+    }
+    dV0 = net.compute_voltage_update(0.0, state, args_no_noise)
+
+    # Add positive per-synapse noise on the active excitatory synapse
+    ps_noise = jnp.zeros_like(W)
+    ps_noise = ps_noise.at[0, 2].set(2e-9)
+    args_with_noise = dict(args_no_noise)
+    args_with_noise["per_synapse_excitatory_noise"] = ps_noise
+    dV1 = net.compute_voltage_update(0.0, state, args_with_noise)
+
+    # Excitatory injection at rest (V < E_E) drives V upward → dV[0] > dV0[0]
+    assert dV1[0] > dV0[0]
+    # Neuron 1 has no excitatory synapse active here so dV should be unchanged
+    assert jnp.isclose(dV1[1], dV0[1], atol=1e-12)


### PR DESCRIPTION
## Status: DRAFT — for evaluation only

This branch is **not requesting a merge**. It's published so Alexander can browse the diff, run the code, and decide whether the per-synapse OUA direction is worth pursuing as a complement to the thesis (possibly post-defense). Renato will share the full formal methodology + results report separately for the scientific evaluation.

## What this branch adds

Eleven commits on top of `main`, rebased onto `4f3159c` (your latest). All changes are **additive** — no existing classes modified beyond a minimal `compute_voltage_update` patch in `base.py` that preserves the original per-neuron path when the per-synapse noise term is absent.

**New modules**
- `models/noise/per_synapse_oup.py` — Ornstein–Uhlenbeck process on individual excitatory synaptic weights (per-synapse geometry, sibling to your `OUP`).
- `models/networks/per_synapse_noisy_network.py` — wrapper routing per-synapse noise into the integrator.
- `models/networks/oua_LIF.py` — `OUAMeanReversionLIFNetwork` (per-synapse OUA mean-reversion consolidation rule with γ-clip Lyapunov safeguard).
- `models/networks/oua_eligibility_LIF.py` — per-synapse eligibility-trace variant (for τ_e → 0 equivalence tests against OUA).
- `models/networks/learning_agent.py` — minimal closed-loop wrapper carrying a filtered scalar RPE; supports a user-provided `task_rpe_fn` callable for Tier-2 tasks. **Note**: this duplicates some of what your new `RewardPrediction` / `Agent` infrastructure (commits `e16985d`, `4c08756`) does — if we pursue this, refactoring `LearningAgent` to reuse `RewardPrediction` is the obvious next step.
- `models/networks/gated_LIF.py`, `_gating.py` — voltage-gate helpers used by the new cells.

**New experiment runners** (`scripts/overnight/`)
- Phase B v2 — 6-cell SST sweep (4 OUA/eligibility cells × per-neuron/per-synapse + 2 gate-off controls), with proper Alexander Eq. 33 (ρ) / Eq. 34 (SNR) metrics computed offline.
- Phase C — closed-loop learning dynamics (η > 0) for all 6 cells.
- Phase D — theory validation (τ_e → 0 equivalence, γ-clip Lyapunov check, Stein-lemma bias).
- Phase E — Tier-2 pattern discrimination at N=100, N=500 (N=1000 deferred to GPU/HPC).

## Validation

- **56/56 tests pass** under `JAX_ENABLE_X64=true`, including 9 OUA-mean-reversion + 7 per-synapse-OUP unit tests.
- Includes a small adaptation for your `simulate_noisy_SNN → solve_ODE` rename in the overnight scripts (commit `e77eb02`).

## Headline scientific results

(Full details in the methodology report Renato will send separately.)

- **Per-neuron OUA (A-PN) quantitatively reproduces your Fig. 4** — ρ peaks at 0.92 at ΔV=2^−11 and decays to 0.19 at ΔV=2^−7; SNR monotonic 0.73 → 0.09.
- **Per-synapse OUA shows negative ρ in the SST** at small ΔV — expected from the dimensionality argument (the learnable synapse's noise doesn't drive postsynaptic spiking, which is dominated by the background input). Predicted to flip on higher-dimensional tasks; tested in Tier-2.
- **Tier-2 at N=500 with proper task-RPE**: all 4 cells learn the target pattern. Eligibility ≫ OUA in absolute selectivity; per-neuron > per-synapse for both consolidation rules. Prediction 1 (per-synapse > per-neuron at low N_eff) **not yet validated** at this scale — likely needs N=1000 + multi-readout DMS task on GPU/HPC.

## Known open issues (in the report)

1. **B-PS eligibility-trace runaway** at large ΔV (W_final = 1184 at ΔV=2^−7) — needs an `update_clip` analogous to OUA's γ-clip.
2. **τ_e equivalence factor-of-2.5 discrepancy** at τ_e = 6 ms (unified §4.5 says they should match in τ_e → 0 limit) — wants a theorist pass.
3. **Stein-lemma bias** is consistently negative (~30–50% of marginal RPE mean) but small in magnitude.

## How to evaluate

```bash
git fetch https://github.com/rcfduarte/adaptive-SNNs.git oua-synaptic-graft
git checkout -b oua-synaptic-graft FETCH_HEAD
pytest tests/ -x   # 56 should pass
```

Smallest standalone runner to inspect: `scripts/overnight/run_paired_comparison.py` (SST sweep).

## What we're asking

Browse the diff, decide whether the per-synapse direction is interesting enough to pursue as a follow-up (timing entirely on your terms — post-thesis is fine). No commitment required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)